### PR TITLE
Bump to pytorch 25.09

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -34,6 +34,7 @@ RUN --mount=type=bind,source=pyproject.toml,target=/workspace/pyproject.toml \
     uv sync --link-mode symlink --locked --all-groups \
         --no-install-package absl-py \
         --no-install-package torch \
+        --no-install-package triton \
         --no-install-package nvidia-cublas-cu12 \
         --no-install-package nvidia-cuda-cupti-cu12 \
         --no-install-package nvidia-cuda-nvrtc-cu12 \


### PR DESCRIPTION
Bump to pytorch 25.09

* Also bump uv version
* Exclude additional nvidia packages that only get installed with the open source pytorch wheel