### PR TITLE
default use_nesterov to false for Muon

### DIFF
--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -64,7 +64,7 @@ class Muon(OrthogonalizedOptimizer):
         params: ParamsT,
         lr: float = 3e-4,
         momentum_beta: float = 0.95,
-        use_nesterov: bool = True,
+        use_nesterov: bool = False,
         weight_decay: float = 0.01,
         use_decoupled_weight_decay: bool = True,
         fp32_matmul_prec: str = "medium",


### PR DESCRIPTION
There are enough results showing use_nesterov makes things worse.