### PR TITLE
Address number of steps issue and be more explicit about the type of iteration

### DIFF
--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -140,7 +140,7 @@ def newton_schulz(
         # For simple, repeat the same coefficients as many times as needed
         coefficient_sets = coefficient_sets * steps
     elif coefficient_type == "polar_express":
-        # For polar_express, steps must be >= 8, repeat last step if steps > 8
+        # For polar_express, steps must be >= num_coeffs, repeat last step if steps > num_coeffs
         if steps < num_coeffs:
             raise ValueError(f"steps ({steps}) must be at least {num_coeffs} for polar_express.")
         if steps > num_coeffs:


### PR DESCRIPTION
[Issue](https://github.com/NVIDIA-NeMo/Emerging-Optimizers/issues/90) raises that the Polar Express paper recommends that for `newton-schulz` steps that are greater than 8, we repeat the last set of `(a,b,c)` coefficients. We previously required that number of steps provided be a multiple of coefficient sets so we could cyclically run the iteration. While not incorrect, it deviated from polar express' recommendation so this PR fixes that. 