### PR TITLE
ci: Fix container build on scheduled main branch run

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -46,8 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: test
     if: |
-      needs.pre-flight.outputs.is_ci_workload == 'false'
-      && needs.pre-flight.outputs.docs_only == 'false'
+      !(needs.pre-flight.outputs.is_ci_workload == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+      || needs.pre-flight.outputs.docs_only == 'true')
     steps:
       - name: Running CI tests
         run: |
@@ -62,7 +63,6 @@ jobs:
         || needs.pre-flight.outputs.is_ci_workload == 'true'
         || needs.pre-flight.outputs.force_run_all == 'true'
       )
-      && needs.pre-flight.outputs.docs_only == 'false'
       && !cancelled()
     with:
       image-name: emerging_optimizers


### PR DESCRIPTION
ci: Fix container build on scheduled main branch run

When `docs_only == True`, it would skip container build on CI runs on main branch, causing main branch CI runs to fail until a new commit that changes code is merged.

This change updates the Github Actions condition to be similar to what is used by other repos where the `needs.pre-flight.outputs.docs_only == 'false'` is removed on the container build job. On a PR when `docs_only == True`, then it will cause `cicd-wait-in-queue` to skip, it will also skip the container build.