### PR TITLE
Clarify momentum style

### DIFF
--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -36,7 +36,7 @@ MuonScaleT = Literal["shape_scaling", "spectral", "unit_rms_norm"]
 class Muon(OrthogonalizedOptimizer):
     """Muon: MomentUm Orthogonalized by Newton-schulz
 
-    Muon runs standard SGD-momentum with Nesterov momentum, and then performs an orthogonalization
+    Muon runs EMA style momentum with Nesterov momentum, and then performs an orthogonalization
     post-processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
     matrix. To efficiently orthogonalize each update, Newton-Schulz iteration is used, which has the
     advantage that it may be stably run on tensor cores on GPUs.

--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -36,7 +36,7 @@ MuonScaleT = Literal["shape_scaling", "spectral", "unit_rms_norm"]
 class Muon(OrthogonalizedOptimizer):
     """Muon: MomentUm Orthogonalized by Newton-schulz
 
-    Muon runs EMA style momentum with Nesterov momentum, and then performs an orthogonalization
+    Muon runs EMA-style momentum with optional Nesterov momentum, and then performs an orthogonalization
     post-processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
     matrix. To efficiently orthogonalize each update, Newton-Schulz iteration is used, which has the
     advantage that it may be stably run on tensor cores on GPUs.

--- a/emerging_optimizers/orthogonalized_optimizers/orthogonalized_optimizer.py
+++ b/emerging_optimizers/orthogonalized_optimizers/orthogonalized_optimizer.py
@@ -30,7 +30,7 @@ from emerging_optimizers.utils import FP32MatmulPrecT
 
 _args_doc = """params: Iterable of parameters to optimize or dicts defining parameter groups
         lr: The learning rate used by the internal SGD.
-        momentum: The momentum used by the internal SGD, EMA style.
+        momentum: The momentum used by the internal SGD, EMA-style.
         weight_decay: The weight decay used by the optimizer, default to be decoupled weight decay.
             See Decoupled Weight Decay Regularization: https://arxiv.org/abs/1711.05101
         nesterov: Whether to use Nesterov-style momentum in the internal SGD.

--- a/emerging_optimizers/orthogonalized_optimizers/orthogonalized_optimizer.py
+++ b/emerging_optimizers/orthogonalized_optimizers/orthogonalized_optimizer.py
@@ -30,7 +30,7 @@ from emerging_optimizers.utils import FP32MatmulPrecT
 
 _args_doc = """params: Iterable of parameters to optimize or dicts defining parameter groups
         lr: The learning rate used by the internal SGD.
-        momentum: The momentum used by the internal SGD.
+        momentum: The momentum used by the internal SGD, EMA style.
         weight_decay: The weight decay used by the optimizer, default to be decoupled weight decay.
             See Decoupled Weight Decay Regularization: https://arxiv.org/abs/1711.05101
         nesterov: Whether to use Nesterov-style momentum in the internal SGD.

--- a/emerging_optimizers/orthogonalized_optimizers/polargrad.py
+++ b/emerging_optimizers/orthogonalized_optimizers/polargrad.py
@@ -32,9 +32,7 @@ __all__ = ["PolarGrad"]
 class PolarGrad(OrthogonalizedOptimizer):
     """PolarGrad: Polar Gradient Methods.
 
-    PolarGrad runs standard SGD-momentum with Nesterov momentum, and then performs an orthogonalization
-    post-processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
-    matrix. Note that the update is also scaled by the nuclear norm of the momentum term. This is
+    Note that the update is scaled by the nuclear norm of the momentum term. This is
     equivalent to solving the steepest descent w.r.t. the spectral norm, as opposed to the LMO formulation
     of Scion and Muon. To efficiently orthogonalize each update, Newton-Schulz iteration is used, which has the
     advantage that it may be stably run on tensor cores on GPUs.

--- a/emerging_optimizers/orthogonalized_optimizers/scion.py
+++ b/emerging_optimizers/orthogonalized_optimizers/scion.py
@@ -32,11 +32,6 @@ __all__ = ["Scion"]
 class Scion(OrthogonalizedOptimizer):
     """Scion: Stochastic CondItional descent with Operator Norms
 
-    Scion runs standard SGD-momentum and then performs an orthogonalization
-    post-processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
-    matrix. To efficiently orthogonalize each update, Newton-Schulz iteration is used, which has the
-    advantage that it may be stably run on tensor cores on GPUs.
-
     This implementation incorporates `step_size` and `spectral_radius`, refer to Scion which views weight decay as constrained
     optimization via Frank-Wolfe.
 


### PR DESCRIPTION
We followed the convention of preceding Muon implementations that use EMA-style momentum, despite the algorithm and math illustration is not always consistent.

This PR clarifies what is used in the code to reduce ambiguity. close #166 .