### PR TITLE
ci: Major refactor of release-workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,13 +77,9 @@ jobs:
   release:
     needs: [pre-flight]
     if: |
-      !cancelled()
-      && (needs.pre-flight.result == 'success' || needs.pre-flight.result == 'skipped')
-      && (
-        github.event_name == 'workflow_dispatch'
-        || !(needs.pre-flight.outputs.docs_only == 'true'
-             || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-      )
+      !cancelled() && !failure()
+      && !(needs.pre-flight.outputs.docs_only == 'true'
+           || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.0.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
       skip-wheel-build: true
       app-id: ${{ vars.BOT_ID }}
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
-      publish-docs: ${{ inputs.publish-docs || false }}
+      publish-docs: true
       docs-target-path: nemo/emerging-optimizers
       docs-fail-on-warning: false
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@d2f3dd32aad11b7034f3f1821174556507d61670
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@64293f6d11ccd1a14a8d23c403761a543b4c21f9
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@43d259e5b5f0a6cb4c14eefa04738a5bdf316fe1
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@d2f3dd32aad11b7034f3f1821174556507d61670
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers
@@ -95,11 +95,7 @@ jobs:
       publish-docs: false
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
-    secrets:
-      TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-      TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
-      BOT_KEY: ${{ secrets.BOT_KEY }}
+    secrets: inherit
 
   release-summary:
     needs: [pre-flight, release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,7 @@ jobs:
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
       publish-docs: ${{ inputs.publish-docs || false }}
       docs-target-path: nemo/emerging-optimizers
+      docs-fail-on-warning: false
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,11 @@ on:
         required: false
         type: string
         default: ""
+      publish-docs:
+        description: Publish docs
+        required: false
+        default: true
+        type: boolean
 
 defaults:
   run:
@@ -92,7 +97,8 @@ jobs:
       skip-wheel-build: true
       app-id: ${{ vars.BOT_ID }}
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
-      publish-docs: false
+      publish-docs: ${{ inputs.publish-docs || false }}
+      docs-target-path: nemo/emerging-optimizers
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: "Release Emerging-Optimizers"
+name: "Build, validate, and release Emerging-Optimizers"
 
 on:
+  push:
+    branches:
+      - main
+      - "r**"
+      - "pull-request/**"
+      - "deploy-release/*"
   workflow_dispatch:
     inputs:
       release-ref:
@@ -21,7 +27,7 @@ on:
         required: true
         type: string
       dry-run:
-        description: Do not publish a wheel and GitHub release.
+        description: Compute the release but do not publish wheel, GH release, or docs.
         required: true
         default: true
         type: boolean
@@ -30,25 +36,93 @@ on:
         required: true
         default: true
         type: boolean
+      generate-changelog:
+        description: Generate changelog
+        required: false
+        default: true
+        type: boolean
       version-bump-branch:
         description: Branch for version bump
         required: true
         type: string
+      gh-release-from-tag:
+        description: Tag of previous release for changelog builder
+        required: false
+        type: string
+        default: ""
+
+defaults:
+  run:
+    shell: bash -x -e -u -o pipefail {0}
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
+  pre-flight:
+    if: github.event_name != 'workflow_dispatch'
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.94.1
+
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.57.0
+    needs: [pre-flight]
+    if: |
+      !cancelled()
+      && (needs.pre-flight.result == 'success' || needs.pre-flight.result == 'skipped')
+      && (
+        github.event_name == 'workflow_dispatch'
+        || !(needs.pre-flight.outputs.docs_only == 'true'
+             || needs.pre-flight.outputs.is_deployment_workflow == 'true')
+      )
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@43d259e5b5f0a6cb4c14eefa04738a5bdf316fe1
     with:
-      release-ref: ${{ inputs.release-ref }}
+      release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers
       library-name: Emerging-Optimizers
-      dry-run: ${{ inputs.dry-run }}
-      version-bump-branch: ${{ inputs.version-bump-branch }}
-      create-gh-release: ${{ inputs.create-gh-release }}
+      validate-only: ${{ github.event_name != 'workflow_dispatch' }}
+      dry-run: ${{ inputs.dry-run || false }}
+      version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
+      create-gh-release: ${{ inputs.create-gh-release || true }}
       packaging: uv
+      skip-wheel-build: true
+      app-id: ${{ vars.BOT_ID }}
+      gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
+      publish-docs: false
+      gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
+      restrict-to-admins: true
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
-      SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
-      PAT: ${{ secrets.PAT }}
+      BOT_KEY: ${{ secrets.BOT_KEY }}
+
+  release-summary:
+    needs: [pre-flight, release]
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+        || always()
+      )
+      && !cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --repo ${{ github.repository }} --json jobs --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required")] | length')
+
+          if [ "${FAILED_JOBS:-0}" -eq 0 ]; then
+              echo "✅ All previous jobs completed successfully"
+              exit 0
+          else
+              echo "❌ Found $FAILED_JOBS failed job(s)"
+              gh run view $GITHUB_RUN_ID --repo ${{ github.repository }} --json jobs --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") | .name'
+              exit 1
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@64293f6d11ccd1a14a8d23c403761a543b4c21f9
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.0.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,6 @@ jobs:
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
       publish-docs: true
       docs-target-path: nemo/emerging-optimizers
-      docs-fail-on-warning: false
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
     secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       !cancelled() && !failure()
       && !(needs.pre-flight.outputs.docs_only == 'true'
            || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@2ba61fb4dc42ce6e8eabac7a6064d73bc962c9ec
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.1.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
       docs-fail-on-warning: false
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
-    secrets: inherit
+    secrets: inherit  # pragma: allowlist secret
 
   release-summary:
     needs: [pre-flight, release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,13 +106,7 @@ jobs:
 
   release-summary:
     needs: [pre-flight, release]
-    if: |
-      (
-        needs.pre-flight.outputs.docs_only == 'true'
-        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
-        || always()
-      )
-      && !cancelled()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Result

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       !cancelled() && !failure()
       && !(needs.pre-flight.outputs.docs_only == 'true'
            || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.0.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@2ba61fb4dc42ce6e8eabac7a6064d73bc962c9ec
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers
@@ -95,6 +95,7 @@ jobs:
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
       publish-docs: true
       docs-target-path: nemo/emerging-optimizers
+      docs-sync-all: true
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
     secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
## Why

See the design discussion in NVIDIA-NeMo/FW-CI-templates#466.

## What

- **Delete** `.github/workflows/build-test-publish-wheel.yml`.
- **Rewrite** `.github/workflows/release.yaml` as the single caller for both `push` and `workflow_dispatch`.

## Test plan

- [x] PR validate-only (push (mirror), sha 66de54d0ec, 2026-05-07T11:27:35Z, success): https://github.com/NVIDIA-NeMo/Emerging-Optimizers/actions/runs/25492996303
- [x] `workflow_dispatch dry-run=true` (sha 66de54d0ec, 2026-05-07T11:28:32Z, success): https://github.com/NVIDIA-NeMo/Emerging-Optimizers/actions/runs/25493037909
- [ ] Real release via `workflow_dispatch dry-run=false` on the next planned RC.

## Rollout

1. Land FW-CI-templates#466.
2. Cut FW-CI-templates `v1.0.0`.
3. Bump the SHA pin in this PR → tag.
