### PR TITLE
fix normuon

### DIFF
--- a/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
@@ -23,7 +23,7 @@ from absl import logging
 from torch.optim.optimizer import ParamsT
 
 from emerging_optimizers import mixin as opt_mixin
-from emerging_optimizers import registry, triton_kernels, utils
+from emerging_optimizers import registry, utils
 from emerging_optimizers.orthogonalized_optimizers import muon, muon_utils
 from emerging_optimizers.orthogonalized_optimizers.muon_utils import NSCoeffT
 from emerging_optimizers.orthogonalized_optimizers.orthogonalized_optimizer import OrthogonalizedOptimizer
@@ -58,7 +58,6 @@ class AdaptiveMuon(OrthogonalizedOptimizer):
         num_ns_steps: The number of iteration steps to use in the Newton-Schulz iteration.
         scale_mode: The type of scale factor to use for the update.
         extra_scale_factor: The additional scale factor to use for the update.
-        use_syrk: Whether to use the Triton kernel for the Newton-Schulz iteration.
         moment2_method: Method for second moment accumulation ("adamuon", "normuon", or "namo").
             - "adamuon": Full elementwise second moment (like AdamW).
             - "normuon": Row or column-wise second moment.
@@ -81,7 +80,6 @@ class AdaptiveMuon(OrthogonalizedOptimizer):
         num_ns_steps: int = 5,
         scale_mode: muon.MuonScaleT = "spectral",
         extra_scale_factor: float = 1.0,
-        use_syrk: bool = False,
         moment2_method: Moment2MethodT = "adamuon",
         beta2: float = 0.95,
         eps: float = 1e-8,
@@ -91,30 +89,17 @@ class AdaptiveMuon(OrthogonalizedOptimizer):
         if num_ns_steps < 1:
             raise ValueError(f"num_ns_steps must be at least 1, got {num_ns_steps}")
 
-        if use_syrk:
-            if torch.cuda.is_available():
-                sm_version = torch.cuda.get_device_capability()
-            else:
-                sm_version = (0, 0)
-            if not triton_kernels.HAS_TRITON_340:  # type: ignore[attr-defined]
-                logging.error("Triton 3.4.0 or higher is required for use_syrk to be True.")
-                use_syrk = False
-            elif sm_version not in ((8, 0), (9, 0), (10, 0), (10, 3)):
-                logging.error(
-                    f"Correctness of Triton kernel on SM {sm_version} cannot be guaranteed. Setting use_syrk to False."
-                )
-                use_syrk = False
-
         self.scale_mode = scale_mode
         self.extra_scale_factor = extra_scale_factor
 
         def raw_orthogonalize_fn(grad: torch.Tensor) -> torch.Tensor:
+            # Adaptive variants normalize the raw Newton-Schulz output first; Muon scale is applied after moment2.
             logging.debug(f"Orthogonalizing grad with {num_ns_steps} steps, {coefficient_type} coefficient")
             return muon_utils.newton_schulz(
                 grad,
                 steps=num_ns_steps,
                 coefficient_type=coefficient_type,
-                use_syrk=use_syrk,
+                use_syrk=False,
             )
 
         super().__init__(

--- a/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
@@ -38,9 +38,10 @@ class AdaptiveMuon(muon.Muon):
     """Adaptive Muon optimizer with adaptive second moment (AdaMuon/NorMuon/NAMO variants).
 
     This class extends Muon by adding adaptive second moment accumulation after
-    orthogonalization. This idea was first explored in D.E. Carlson, E. Collins,
-    Ya-Ping Hsieh, L. Carin, and V. Cevher. *Preconditioned spectral descent for
-    deep learning.* In Advances in neural information processing systems 28 (2015).
+    raw orthogonalization and before Muon's update scaling. This idea was first
+    explored in D.E. Carlson, E. Collins, Ya-Ping Hsieh, L. Carin, and V. Cevher.
+    *Preconditioned spectral descent for deep learning.* In Advances in neural
+    information processing systems 28 (2015).
     The step() method is overridden to include second moment normalization logic.
 
     Args:
@@ -180,7 +181,7 @@ class AdaptiveMuon(muon.Muon):
         2. Returns the adaptively scaled gradient
 
         Args:
-            orth_grad: The orthogonalized gradient tensor.
+            orth_grad: The raw orthogonalized gradient tensor before Muon update scaling.
             moment2: The second moment buffer from state.
             beta2: The exponential decay rate for second moment.
             eps: Small constant for numerical stability.
@@ -282,8 +283,7 @@ class AdaptiveMuon(muon.Muon):
                     grad = exp_avg
 
                 with utils.fp32_matmul_precision(self.fp32_matmul_prec):
-                    group_kwargs = {k: v for k, v in group.items() if k != "params"}
-                    orth_grad = self.orthogonalize(p, grad, **group_kwargs)
+                    orth_grad = self._orthogonalize_grad(grad)
 
                 update = self._apply_moment2_normalization(
                     orth_grad=orth_grad,
@@ -293,6 +293,7 @@ class AdaptiveMuon(muon.Muon):
                     raw_grad=raw_grad,
                     pre_orth_grad=grad if raw_grad is not None else None,
                 )
+                update = self._apply_muon_scale(update, grad)
 
                 # perform weight update with pre and post weight update functions for subclass customization
                 self.pre_weight_update_fn_inplace(p, update)

--- a/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
@@ -19,12 +19,14 @@ if TYPE_CHECKING:
     from typing import overload
 
 import torch
+from absl import logging
 from torch.optim.optimizer import ParamsT
 
 from emerging_optimizers import mixin as opt_mixin
-from emerging_optimizers import registry, utils
-from emerging_optimizers.orthogonalized_optimizers import muon
+from emerging_optimizers import registry, triton_kernels, utils
+from emerging_optimizers.orthogonalized_optimizers import muon, muon_utils
 from emerging_optimizers.orthogonalized_optimizers.muon_utils import NSCoeffT
+from emerging_optimizers.orthogonalized_optimizers.orthogonalized_optimizer import OrthogonalizedOptimizer
 from emerging_optimizers.utils import FP32MatmulPrecT
 
 
@@ -34,7 +36,7 @@ Moment2MethodT = Literal["adamuon", "normuon", "namo"]
 
 
 @registry.register_optimizer("adaptive_muon")
-class AdaptiveMuon(muon.Muon):
+class AdaptiveMuon(OrthogonalizedOptimizer):
     """Adaptive Muon optimizer with adaptive second moment (AdaMuon/NorMuon/NAMO variants).
 
     This class extends Muon by adding adaptive second moment accumulation after
@@ -86,27 +88,55 @@ class AdaptiveMuon(muon.Muon):
     ):
         if moment2_method == "namo" and weight_decay_method == "l2":
             raise ValueError('moment2_method="namo" is incompatible with weight_decay_method="l2"')
+        if num_ns_steps < 1:
+            raise ValueError(f"num_ns_steps must be at least 1, got {num_ns_steps}")
+
+        if use_syrk:
+            if torch.cuda.is_available():
+                sm_version = torch.cuda.get_device_capability()
+            else:
+                sm_version = (0, 0)
+            if not triton_kernels.HAS_TRITON_340:  # type: ignore[attr-defined]
+                logging.error("Triton 3.4.0 or higher is required for use_syrk to be True.")
+                use_syrk = False
+            elif sm_version not in ((8, 0), (9, 0), (10, 0), (10, 3)):
+                logging.error(
+                    f"Correctness of Triton kernel on SM {sm_version} cannot be guaranteed. Setting use_syrk to False."
+                )
+                use_syrk = False
+
+        self.scale_mode = scale_mode
+        self.extra_scale_factor = extra_scale_factor
+
+        def raw_orthogonalize_fn(grad: torch.Tensor) -> torch.Tensor:
+            logging.debug(f"Orthogonalizing grad with {num_ns_steps} steps, {coefficient_type} coefficient")
+            return muon_utils.newton_schulz(
+                grad,
+                steps=num_ns_steps,
+                coefficient_type=coefficient_type,
+                use_syrk=use_syrk,
+            )
 
         super().__init__(
             params,
-            lr=lr,
-            momentum=momentum,
-            weight_decay=weight_decay,
+            lr,
+            momentum,
+            weight_decay,
             nesterov=nesterov,
             weight_decay_method=weight_decay_method,
             fp32_matmul_prec=fp32_matmul_prec,
-            coefficient_type=coefficient_type,
-            num_ns_steps=num_ns_steps,
-            scale_mode=scale_mode,
-            extra_scale_factor=extra_scale_factor,
-            use_syrk=use_syrk,
+            scaled_orthogonalize_fn=raw_orthogonalize_fn,
         )
         self.moment2_method = moment2_method
-        self.scaled_orthogonalize_fn = self._orthogonalize_grad
 
         for group in self.param_groups:
             group.setdefault("beta2", beta2)
             group.setdefault("eps", eps)
+
+    def _apply_muon_scale(self, update: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
+        scale_factor = muon.get_muon_scale_factor(reference.size(-2), reference.size(-1), mode=self.scale_mode)
+        logging.debug(f"Applying Muon scale factor {scale_factor}, extra_scale_factor={self.extra_scale_factor}")
+        return update * scale_factor * self.extra_scale_factor
 
     @torch.no_grad()  # type: ignore[misc]
     @override

--- a/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
@@ -118,8 +118,8 @@ class AdaptiveMuon(OrthogonalizedOptimizer):
             group.setdefault("beta2", beta2)
             group.setdefault("eps", eps)
 
-    def _apply_muon_scale(self, update: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
-        scale_factor = muon.get_muon_scale_factor(reference.size(-2), reference.size(-1), mode=self.scale_mode)
+    def _apply_muon_scale(self, update: torch.Tensor, size_out: int, size_in: int) -> torch.Tensor:
+        scale_factor = muon.get_muon_scale_factor(size_out, size_in, mode=self.scale_mode)
         logging.debug(f"Applying Muon scale factor {scale_factor}, extra_scale_factor={self.extra_scale_factor}")
         return update * scale_factor * self.extra_scale_factor
 
@@ -310,7 +310,7 @@ class AdaptiveMuon(OrthogonalizedOptimizer):
                     raw_grad=raw_grad,
                     pre_orth_grad=grad if raw_grad is not None else None,
                 )
-                update = self._apply_muon_scale(update, grad)
+                update = self._apply_muon_scale(update, update.size(-2), update.size(-1))
 
                 # perform weight update with pre and post weight update functions for subclass customization
                 self.pre_weight_update_fn_inplace(p, update)

--- a/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
@@ -102,6 +102,7 @@ class AdaptiveMuon(muon.Muon):
             use_syrk=use_syrk,
         )
         self.moment2_method = moment2_method
+        self.scaled_orthogonalize_fn = self._orthogonalize_grad
 
         for group in self.param_groups:
             group.setdefault("beta2", beta2)
@@ -283,7 +284,8 @@ class AdaptiveMuon(muon.Muon):
                     grad = exp_avg
 
                 with utils.fp32_matmul_precision(self.fp32_matmul_prec):
-                    orth_grad = self._orthogonalize_grad(grad)
+                    group_kwargs = {k: v for k, v in group.items() if k != "params"}
+                    orth_grad = self.orthogonalize(p, grad, **group_kwargs)
 
                 update = self._apply_moment2_normalization(
                     orth_grad=orth_grad,

--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -104,15 +104,19 @@ class Muon(OrthogonalizedOptimizer):
                 )
                 use_syrk = False
 
-        self.coefficient_type = coefficient_type
-        self.num_ns_steps = num_ns_steps
-        self.scale_mode = scale_mode
-        self.extra_scale_factor = extra_scale_factor
-        self.use_syrk = use_syrk
-
         def scaled_orthogonalize_fn(grad: torch.Tensor) -> torch.Tensor:
-            orth_grad = self._orthogonalize_grad(grad)
-            return self._apply_muon_scale(orth_grad, grad)
+            logging.debug(
+                f"Orthogonalizing grad with {num_ns_steps} steps, {coefficient_type} coefficient, "
+                f"{scale_mode} scale mode, extra_scale_factor={extra_scale_factor}"
+            )
+            orth_grad = muon_utils.newton_schulz(
+                grad,
+                steps=num_ns_steps,
+                coefficient_type=coefficient_type,
+                use_syrk=use_syrk,
+            )
+            scale_factor = get_muon_scale_factor(grad.size(-2), grad.size(-1), mode=scale_mode)
+            return orth_grad * scale_factor * extra_scale_factor
 
         super().__init__(
             params,
@@ -124,20 +128,6 @@ class Muon(OrthogonalizedOptimizer):
             fp32_matmul_prec=fp32_matmul_prec,
             scaled_orthogonalize_fn=scaled_orthogonalize_fn,
         )
-
-    def _orthogonalize_grad(self, grad: torch.Tensor) -> torch.Tensor:
-        logging.debug(f"Orthogonalizing grad with {self.num_ns_steps} steps, {self.coefficient_type} coefficient")
-        return muon_utils.newton_schulz(
-            grad,
-            steps=self.num_ns_steps,
-            coefficient_type=self.coefficient_type,
-            use_syrk=self.use_syrk,
-        )
-
-    def _apply_muon_scale(self, update: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
-        scale_factor = get_muon_scale_factor(reference.size(-2), reference.size(-1), mode=self.scale_mode)
-        logging.debug(f"Applying Muon scale factor {scale_factor}, extra_scale_factor={self.extra_scale_factor}")
-        return update * scale_factor * self.extra_scale_factor
 
 
 Muon.__doc__ = Muon.__doc__.format(_args_doc=_args_doc)  # type: ignore[union-attr]

--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -126,10 +126,7 @@ class Muon(OrthogonalizedOptimizer):
         )
 
     def _orthogonalize_grad(self, grad: torch.Tensor) -> torch.Tensor:
-        logging.debug(
-            f"Orthogonalizing grad with {self.num_ns_steps} steps, {self.coefficient_type} coefficient, "
-            f"{self.scale_mode} scale mode, extra_scale_factor={self.extra_scale_factor}"
-        )
+        logging.debug(f"Orthogonalizing grad with {self.num_ns_steps} steps, {self.coefficient_type} coefficient")
         return muon_utils.newton_schulz(
             grad,
             steps=self.num_ns_steps,
@@ -139,6 +136,7 @@ class Muon(OrthogonalizedOptimizer):
 
     def _apply_muon_scale(self, update: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
         scale_factor = get_muon_scale_factor(reference.size(-2), reference.size(-1), mode=self.scale_mode)
+        logging.debug(f"Applying Muon scale factor {scale_factor}, extra_scale_factor={self.extra_scale_factor}")
         return update * scale_factor * self.extra_scale_factor
 
 

--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -104,19 +104,15 @@ class Muon(OrthogonalizedOptimizer):
                 )
                 use_syrk = False
 
+        self.coefficient_type = coefficient_type
+        self.num_ns_steps = num_ns_steps
+        self.scale_mode = scale_mode
+        self.extra_scale_factor = extra_scale_factor
+        self.use_syrk = use_syrk
+
         def scaled_orthogonalize_fn(grad: torch.Tensor) -> torch.Tensor:
-            logging.debug(
-                f"Orthogonalizing grad with {num_ns_steps} steps, {coefficient_type} coefficient, "
-                f"{scale_mode} scale mode, extra_scale_factor={extra_scale_factor}"
-            )
-            orth_grad = muon_utils.newton_schulz(
-                grad,
-                steps=num_ns_steps,
-                coefficient_type=coefficient_type,
-                use_syrk=use_syrk,
-            )
-            scale_factor = get_muon_scale_factor(grad.size(-2), grad.size(-1), mode=scale_mode)
-            return orth_grad * scale_factor * extra_scale_factor
+            orth_grad = self._orthogonalize_grad(grad)
+            return self._apply_muon_scale(orth_grad, grad)
 
         super().__init__(
             params,
@@ -128,6 +124,22 @@ class Muon(OrthogonalizedOptimizer):
             fp32_matmul_prec=fp32_matmul_prec,
             scaled_orthogonalize_fn=scaled_orthogonalize_fn,
         )
+
+    def _orthogonalize_grad(self, grad: torch.Tensor) -> torch.Tensor:
+        logging.debug(
+            f"Orthogonalizing grad with {self.num_ns_steps} steps, {self.coefficient_type} coefficient, "
+            f"{self.scale_mode} scale mode, extra_scale_factor={self.extra_scale_factor}"
+        )
+        return muon_utils.newton_schulz(
+            grad,
+            steps=self.num_ns_steps,
+            coefficient_type=self.coefficient_type,
+            use_syrk=self.use_syrk,
+        )
+
+    def _apply_muon_scale(self, update: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
+        scale_factor = get_muon_scale_factor(reference.size(-2), reference.size(-1), mode=self.scale_mode)
+        return update * scale_factor * self.extra_scale_factor
 
 
 Muon.__doc__ = Muon.__doc__.format(_args_doc=_args_doc)  # type: ignore[union-attr]

--- a/tests/test_adaptive_muon.py
+++ b/tests/test_adaptive_muon.py
@@ -150,8 +150,8 @@ class AdaptiveMuonTest(parameterized.TestCase):
             *shape, mode="shape_scaling"
         )
         torch.testing.assert_close(
-            initial_param - spectral_param.data,
-            (initial_param - shape_scaled_param.data) * expected_scale_ratio,
+            initial_param - spectral_param.detach(),
+            (initial_param - shape_scaled_param.detach()) * expected_scale_ratio,
             atol=1e-6,
             rtol=1e-6,
         )

--- a/tests/test_adaptive_muon.py
+++ b/tests/test_adaptive_muon.py
@@ -101,6 +101,54 @@ class AdaptiveMuonTest(parameterized.TestCase):
         elif moment2_method == "namo":
             self.assertEqual(moment2.shape, torch.Size([1]))
 
+    def test_moment2_accumulates_before_muon_update_scaling(self) -> None:
+        """Test that Muon update scaling is applied after second-moment normalization."""
+        shape = (4, 16)
+        param_data = torch.randn(shape, dtype=torch.float32, device=FLAGS.device)
+        grad = torch.randn_like(param_data)
+
+        spectral_param = nn.Parameter(param_data.clone())
+        spectral_param.grad = grad.clone()
+        spectral_opt = AdaptiveMuon(
+            [spectral_param],
+            lr=0.01,
+            momentum=0.0,
+            weight_decay=0.0,
+            moment2_method="adamuon",
+            beta2=0.0,
+            scale_mode="spectral",
+            fp32_matmul_prec="highest",
+        )
+
+        shape_scaled_param = nn.Parameter(param_data.clone())
+        shape_scaled_param.grad = grad.clone()
+        shape_scaled_opt = AdaptiveMuon(
+            [shape_scaled_param],
+            lr=0.01,
+            momentum=0.0,
+            weight_decay=0.0,
+            moment2_method="adamuon",
+            beta2=0.0,
+            scale_mode="shape_scaling",
+            fp32_matmul_prec="highest",
+        )
+
+        spectral_opt.step()
+        shape_scaled_opt.step()
+
+        torch.testing.assert_close(
+            spectral_opt.state[spectral_param]["moment2_buffer"],
+            shape_scaled_opt.state[shape_scaled_param]["moment2_buffer"],
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            param_data - spectral_param.data,
+            (param_data - shape_scaled_param.data) * 4.0,
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
     @parameterized.parameters(
         *({"moment2_method": moment2_method} for moment2_method in MOMENT2_METHODS),
     )

--- a/tests/test_adaptive_muon.py
+++ b/tests/test_adaptive_muon.py
@@ -23,6 +23,7 @@ from emerging_optimizers.orthogonalized_optimizers.adaptive_muon import (
     AdaptiveMuon,
     Moment2MethodT,
 )
+from emerging_optimizers.orthogonalized_optimizers.muon import get_muon_scale_factor
 
 
 flags.DEFINE_enum("device", "cpu", ["cpu", "cuda"], "Device to run tests on")
@@ -107,10 +108,10 @@ class AdaptiveMuonTest(parameterized.TestCase):
     def test_moment2_accumulates_before_muon_update_scaling(self, moment2_method) -> None:
         """Test that Muon update scaling is applied after second-moment normalization."""
         shape = (4, 16)
-        param_data = torch.randn(shape, dtype=torch.float32, device=FLAGS.device)
-        grad = torch.randn_like(param_data)
+        initial_param = torch.randn(shape, dtype=torch.float32, device=FLAGS.device)
+        grad = torch.randn_like(initial_param)
 
-        spectral_param = nn.Parameter(param_data.clone())
+        spectral_param = nn.Parameter(initial_param.clone())
         spectral_param.grad = grad.clone()
         spectral_opt = AdaptiveMuon(
             [spectral_param],
@@ -123,7 +124,7 @@ class AdaptiveMuonTest(parameterized.TestCase):
             fp32_matmul_prec="highest",
         )
 
-        shape_scaled_param = nn.Parameter(param_data.clone())
+        shape_scaled_param = nn.Parameter(initial_param.clone())
         shape_scaled_param.grad = grad.clone()
         shape_scaled_opt = AdaptiveMuon(
             [shape_scaled_param],
@@ -145,9 +146,12 @@ class AdaptiveMuonTest(parameterized.TestCase):
             atol=0.0,
             rtol=0.0,
         )
+        expected_scale_ratio = get_muon_scale_factor(*shape, mode="spectral") / get_muon_scale_factor(
+            *shape, mode="shape_scaling"
+        )
         torch.testing.assert_close(
-            param_data - spectral_param.data,
-            (param_data - shape_scaled_param.data) * 4.0,
+            initial_param - spectral_param.data,
+            (initial_param - shape_scaled_param.data) * expected_scale_ratio,
             atol=1e-6,
             rtol=1e-6,
         )

--- a/tests/test_adaptive_muon.py
+++ b/tests/test_adaptive_muon.py
@@ -101,7 +101,10 @@ class AdaptiveMuonTest(parameterized.TestCase):
         elif moment2_method == "namo":
             self.assertEqual(moment2.shape, torch.Size([1]))
 
-    def test_moment2_accumulates_before_muon_update_scaling(self) -> None:
+    @parameterized.parameters(
+        *({"moment2_method": moment2_method} for moment2_method in MOMENT2_METHODS),
+    )
+    def test_moment2_accumulates_before_muon_update_scaling(self, moment2_method) -> None:
         """Test that Muon update scaling is applied after second-moment normalization."""
         shape = (4, 16)
         param_data = torch.randn(shape, dtype=torch.float32, device=FLAGS.device)
@@ -114,7 +117,7 @@ class AdaptiveMuonTest(parameterized.TestCase):
             lr=0.01,
             momentum=0.0,
             weight_decay=0.0,
-            moment2_method="adamuon",
+            moment2_method=moment2_method,
             beta2=0.0,
             scale_mode="spectral",
             fp32_matmul_prec="highest",
@@ -127,7 +130,7 @@ class AdaptiveMuonTest(parameterized.TestCase):
             lr=0.01,
             momentum=0.0,
             weight_decay=0.0,
-            moment2_method="adamuon",
+            moment2_method=moment2_method,
             beta2=0.0,
             scale_mode="shape_scaling",
             fp32_matmul_prec="highest",


### PR DESCRIPTION
Muon's `scaled_orthogonalize_fn` does both orth + lr scaling. Normuon needs only orthogonalization and applies LR scaling only after second moment. This decouples the 2 ops and only uses 1 of them in NorMuon 