### PR TITLE
Fix NorMuon update norm scaling

### DIFF
--- a/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
@@ -123,8 +123,12 @@ class AdaptiveMuon(OrthogonalizedOptimizer):
         logging.debug(f"Applying Muon scale factor {scale_factor}, extra_scale_factor={self.extra_scale_factor}")
         return update * scale_factor * self.extra_scale_factor
 
-    @staticmethod
-    def _match_frobenius_norm(update: torch.Tensor, reference: torch.Tensor, eps: float) -> torch.Tensor:
+    def _match_frobenius_norm(
+        self,
+        update: torch.Tensor,
+        reference: torch.Tensor,
+        eps: float,
+    ) -> torch.Tensor:
         """Scale update to match the Frobenius norm of reference."""
         update_norm = torch.linalg.vector_norm(update)
         reference_norm = torch.linalg.vector_norm(reference)

--- a/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py
@@ -123,6 +123,13 @@ class AdaptiveMuon(OrthogonalizedOptimizer):
         logging.debug(f"Applying Muon scale factor {scale_factor}, extra_scale_factor={self.extra_scale_factor}")
         return update * scale_factor * self.extra_scale_factor
 
+    @staticmethod
+    def _match_frobenius_norm(update: torch.Tensor, reference: torch.Tensor, eps: float) -> torch.Tensor:
+        """Scale update to match the Frobenius norm of reference."""
+        update_norm = torch.linalg.vector_norm(update)
+        reference_norm = torch.linalg.vector_norm(reference)
+        return update * (reference_norm / update_norm.clamp_min(eps))
+
     @torch.no_grad()  # type: ignore[misc]
     @override
     def _init_group(
@@ -229,7 +236,9 @@ class AdaptiveMuon(OrthogonalizedOptimizer):
 
             # NorMuon uses reciprocal square root with clamping
             step_size = moment2.clamp_min(eps).rsqrt_()
-            return orth_grad * step_size
+            update = orth_grad * step_size
+            # Preserve the raw orthogonalized update norm before applying Muon's scale factor.
+            return self._match_frobenius_norm(update, orth_grad, eps)
 
         elif self.moment2_method == "namo":
             if raw_grad is None or pre_orth_grad is None:

--- a/tests/test_adaptive_muon.py
+++ b/tests/test_adaptive_muon.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 from absl import flags, logging
 from absl.testing import absltest, parameterized
 
+from emerging_optimizers import utils
 from emerging_optimizers.orthogonalized_optimizers.adaptive_muon import (
     AdaptiveMuon,
     Moment2MethodT,
@@ -156,34 +157,48 @@ class AdaptiveMuonTest(parameterized.TestCase):
             rtol=1e-6,
         )
 
-    def test_normuon_preserves_pre_scale_frobenius_norm(self) -> None:
-        """Test that NorMuon adaptation preserves the raw orthogonalized update scale."""
-        shape = (16, 4)
-        orth_grad = torch.arange(1, shape[0] * shape[1] + 1, dtype=torch.float32, device=FLAGS.device).reshape(shape)
-        moment2 = torch.zeros(shape[0], 1, dtype=orth_grad.dtype, device=orth_grad.device)
-        test_param = nn.Parameter(torch.empty(shape, dtype=torch.float32, device=FLAGS.device))
+    @parameterized.parameters({"shape": (16, 4)}, {"shape": (4, 16)})
+    def test_normuon_step_preserves_pre_scale_frobenius_norm(self, shape) -> None:
+        """Test that NorMuon preserves the raw orthogonalized update scale through step()."""
+        numel = shape[0] * shape[1]
+        initial_param = torch.linspace(-0.5, 0.5, numel, dtype=torch.float32, device=FLAGS.device).reshape(shape)
+        grads = (
+            torch.arange(1, numel + 1, dtype=torch.float32, device=FLAGS.device).reshape(shape),
+            torch.arange(numel, 0, -1, dtype=torch.float32, device=FLAGS.device).reshape(shape),
+        )
+        lr = 0.01
+        test_param = nn.Parameter(initial_param.clone())
         adaptive_opt = AdaptiveMuon(
             [test_param],
-            lr=0.01,
+            lr=lr,
             momentum=0.0,
             weight_decay=0.0,
             moment2_method="normuon",
+            beta2=0.5,
+            scale_mode="spectral",
             fp32_matmul_prec="highest",
         )
+        scale_factor = get_muon_scale_factor(*shape, mode="spectral")
 
-        update = adaptive_opt._apply_moment2_normalization(
-            orth_grad=orth_grad,
-            moment2=moment2,
-            beta2=0.0,
-            eps=1e-8,
-        )
+        for grad in grads:
+            param_before_step = test_param.detach().clone()
+            test_param.grad = grad.clone()
+            with utils.fp32_matmul_precision("highest"):
+                orth_grad = adaptive_opt.orthogonalize(test_param, grad)
 
-        torch.testing.assert_close(
-            torch.linalg.vector_norm(update),
-            torch.linalg.vector_norm(orth_grad),
-            atol=1e-6,
-            rtol=1e-6,
-        )
+            adaptive_opt.step()
+
+            state = adaptive_opt.state[test_param]
+            self.assertIn("moment2_buffer", state)
+            self.assertGreater(torch.linalg.vector_norm(state["moment2_buffer"]).item(), 0.0)
+            applied_update = (param_before_step - test_param.detach()) / lr
+            pre_scale_update = applied_update / scale_factor
+            torch.testing.assert_close(
+                torch.linalg.vector_norm(pre_scale_update),
+                torch.linalg.vector_norm(orth_grad),
+                atol=1e-5,
+                rtol=1e-5,
+            )
 
     @parameterized.parameters(
         *({"moment2_method": moment2_method} for moment2_method in MOMENT2_METHODS),

--- a/tests/test_adaptive_muon.py
+++ b/tests/test_adaptive_muon.py
@@ -19,7 +19,6 @@ import torch.nn as nn
 from absl import flags, logging
 from absl.testing import absltest, parameterized
 
-from emerging_optimizers import utils
 from emerging_optimizers.orthogonalized_optimizers.adaptive_muon import (
     AdaptiveMuon,
     Moment2MethodT,
@@ -160,44 +159,54 @@ class AdaptiveMuonTest(parameterized.TestCase):
     @parameterized.parameters({"shape": (16, 4)}, {"shape": (4, 16)})
     def test_normuon_step_preserves_pre_scale_frobenius_norm(self, shape) -> None:
         """Test that NorMuon preserves the raw orthogonalized update scale through step()."""
-        numel = shape[0] * shape[1]
-        initial_param = torch.linspace(-0.5, 0.5, numel, dtype=torch.float32, device=FLAGS.device).reshape(shape)
-        grads = (
-            torch.arange(1, numel + 1, dtype=torch.float32, device=FLAGS.device).reshape(shape),
-            torch.arange(numel, 0, -1, dtype=torch.float32, device=FLAGS.device).reshape(shape),
-        )
-        lr = 0.01
-        test_param = nn.Parameter(initial_param.clone())
-        adaptive_opt = AdaptiveMuon(
+
+        class CaptureUpdateAdaptiveMuon(AdaptiveMuon):
+            def orthogonalize(self, p, grad, **kwargs):
+                return grad.clone()
+
+            def pre_weight_update_fn_inplace(self, p, update) -> None:
+                self.last_update = update.clone()
+
+        factors = torch.tensor([1.0] * 4 + [2.0] * 11 + [4.0], device=FLAGS.device)
+        if shape[-2] >= shape[-1]:
+            grad = factors[:, None].expand(shape).clone()
+            expected_moment2 = factors.square()[:, None]
+        else:
+            grad = factors[None, :].expand(shape).clone()
+            expected_moment2 = factors.square()[None, :]
+
+        test_param = nn.Parameter(torch.zeros(shape, dtype=torch.float32, device=FLAGS.device))
+        adaptive_opt = CaptureUpdateAdaptiveMuon(
             [test_param],
-            lr=lr,
+            lr=0.01,
             momentum=0.0,
             weight_decay=0.0,
             moment2_method="normuon",
-            beta2=0.5,
+            beta2=0.0,
             scale_mode="spectral",
             fp32_matmul_prec="highest",
         )
-        scale_factor = get_muon_scale_factor(*shape, mode="spectral")
+        expected_update = torch.full_like(grad, 2 * get_muon_scale_factor(*shape, mode="spectral"))
 
-        for grad in grads:
-            param_before_step = test_param.detach().clone()
+        for beta2 in (0.0, 0.5):
+            adaptive_opt.param_groups[0]["beta2"] = beta2
             test_param.grad = grad.clone()
-            with utils.fp32_matmul_precision("highest"):
-                orth_grad = adaptive_opt.orthogonalize(test_param, grad)
 
             adaptive_opt.step()
 
             state = adaptive_opt.state[test_param]
             self.assertIn("moment2_buffer", state)
-            self.assertGreater(torch.linalg.vector_norm(state["moment2_buffer"]).item(), 0.0)
-            applied_update = (param_before_step - test_param.detach()) / lr
-            pre_scale_update = applied_update / scale_factor
             torch.testing.assert_close(
-                torch.linalg.vector_norm(pre_scale_update),
-                torch.linalg.vector_norm(orth_grad),
-                atol=1e-5,
-                rtol=1e-5,
+                state["moment2_buffer"],
+                expected_moment2,
+                atol=0.0,
+                rtol=0.0,
+            )
+            torch.testing.assert_close(
+                adaptive_opt.last_update,
+                expected_update,
+                atol=0.0,
+                rtol=0.0,
             )
 
     @parameterized.parameters(

--- a/tests/test_adaptive_muon.py
+++ b/tests/test_adaptive_muon.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 from absl import flags, logging
 from absl.testing import absltest, parameterized
 
+from emerging_optimizers import utils
 from emerging_optimizers.orthogonalized_optimizers.adaptive_muon import (
     AdaptiveMuon,
     Moment2MethodT,
@@ -160,25 +161,17 @@ class AdaptiveMuonTest(parameterized.TestCase):
     def test_normuon_step_preserves_pre_scale_frobenius_norm(self, shape) -> None:
         """Test that NorMuon preserves the raw orthogonalized update scale through step()."""
 
-        class CaptureUpdateAdaptiveMuon(AdaptiveMuon):
-            def orthogonalize(self, p, grad, **kwargs):
-                return grad.clone()
-
-            def pre_weight_update_fn_inplace(self, p, update) -> None:
-                self.last_update = update.clone()
-
         factors = torch.tensor([1.0] * 4 + [2.0] * 11 + [4.0], device=FLAGS.device)
         if shape[-2] >= shape[-1]:
             grad = factors[:, None].expand(shape).clone()
-            expected_moment2 = factors.square()[:, None]
         else:
             grad = factors[None, :].expand(shape).clone()
-            expected_moment2 = factors.square()[None, :]
 
+        lr = 0.125  # Power-of-two LR keeps update recovery from the param delta exact.
         test_param = nn.Parameter(torch.zeros(shape, dtype=torch.float32, device=FLAGS.device))
-        adaptive_opt = CaptureUpdateAdaptiveMuon(
+        adaptive_opt = AdaptiveMuon(
             [test_param],
-            lr=0.01,
+            lr=lr,
             momentum=0.0,
             weight_decay=0.0,
             moment2_method="normuon",
@@ -186,11 +179,25 @@ class AdaptiveMuonTest(parameterized.TestCase):
             scale_mode="spectral",
             fp32_matmul_prec="highest",
         )
-        expected_update = torch.full_like(grad, 2 * get_muon_scale_factor(*shape, mode="spectral"))
+        eps = adaptive_opt.param_groups[0]["eps"]
+        scale_factor = get_muon_scale_factor(*shape, mode="spectral")
 
         for beta2 in (0.0, 0.5):
             adaptive_opt.param_groups[0]["beta2"] = beta2
             test_param.grad = grad.clone()
+            group_kwargs = {k: v for k, v in adaptive_opt.param_groups[0].items() if k != "params"}
+            with utils.fp32_matmul_precision(adaptive_opt.fp32_matmul_prec):
+                orth_grad = adaptive_opt.orthogonalize(test_param, test_param.grad, **group_kwargs)
+
+            avg_dim = -1 if orth_grad.shape[-2] >= orth_grad.shape[-1] else -2
+            expected_moment2 = orth_grad.square().mean(dim=avg_dim, keepdim=True)
+            step_size = expected_moment2.clamp_min(eps).rsqrt_()
+            normalized_update = orth_grad * step_size
+            expected_pre_scale_update = normalized_update * (
+                torch.linalg.vector_norm(orth_grad) / torch.linalg.vector_norm(normalized_update).clamp_min(eps)
+            )
+            expected_update = expected_pre_scale_update * scale_factor
+            param_before_step = test_param.detach().clone()
 
             adaptive_opt.step()
 
@@ -202,8 +209,9 @@ class AdaptiveMuonTest(parameterized.TestCase):
                 atol=0.0,
                 rtol=0.0,
             )
+            applied_update = (param_before_step - test_param.detach()) / lr
             torch.testing.assert_close(
-                adaptive_opt.last_update,
+                applied_update,
                 expected_update,
                 atol=0.0,
                 rtol=0.0,

--- a/tests/test_adaptive_muon.py
+++ b/tests/test_adaptive_muon.py
@@ -156,6 +156,35 @@ class AdaptiveMuonTest(parameterized.TestCase):
             rtol=1e-6,
         )
 
+    def test_normuon_preserves_pre_scale_frobenius_norm(self) -> None:
+        """Test that NorMuon adaptation preserves the raw orthogonalized update scale."""
+        shape = (16, 4)
+        orth_grad = torch.arange(1, shape[0] * shape[1] + 1, dtype=torch.float32, device=FLAGS.device).reshape(shape)
+        moment2 = torch.zeros(shape[0], 1, dtype=orth_grad.dtype, device=orth_grad.device)
+        test_param = nn.Parameter(torch.empty(shape, dtype=torch.float32, device=FLAGS.device))
+        adaptive_opt = AdaptiveMuon(
+            [test_param],
+            lr=0.01,
+            momentum=0.0,
+            weight_decay=0.0,
+            moment2_method="normuon",
+            fp32_matmul_prec="highest",
+        )
+
+        update = adaptive_opt._apply_moment2_normalization(
+            orth_grad=orth_grad,
+            moment2=moment2,
+            beta2=0.0,
+            eps=1e-8,
+        )
+
+        torch.testing.assert_close(
+            torch.linalg.vector_norm(update),
+            torch.linalg.vector_norm(orth_grad),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
     @parameterized.parameters(
         *({"moment2_method": moment2_method} for moment2_method in MOMENT2_METHODS),
     )


### PR DESCRIPTION
## Summary

  Fixes NorMuon update scaling in `AdaptiveMuon`.

  Previously, the `normuon` path applied row/column second-moment normalization to the raw orthogonalized update, then immediately applied the standard Muon scale factor. This can make the pre-scale
  adapted update have Frobenius norm near `sqrt(m*n)` instead of the raw orthogonalized update norm, so the final update can become larger than Muon by roughly `sqrt(max(m, n))`.

  This change re-matches the Frobenius norm of the Normuon-adapted update to the raw orthogonalized update before applying Muon scaling. That preserves the adaptive direction from Normuon while keeping
  the final update scale compatible with Muon.

  ## Changes

  - Added `_match_frobenius_norm(...)` helper.
  - Applied Frobenius norm re-matching in the `moment2_method="normuon"` path.
  - Added a regression test verifying that Normuon preserves the pre-Muon-scale Frobenius norm.

  ## Testing

  - `python -m py_compile emerging_optimizers/orthogonalized_optimizers/adaptive_muon.py tests/test_adaptive_muon.py`