### PR TITLE
ci: validate release branch-rules

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       !cancelled() && !failure()
       && !(needs.pre-flight.outputs.docs_only == 'true'
            || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@d8ca5ec4a4c4242d0bc2438aa838adebd83e05c4
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.4.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       !cancelled() && !failure()
       && !(needs.pre-flight.outputs.docs_only == 'true'
            || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@57cc8e1ed81d8a1d83cecb2e4a54e04144623bcf
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@d8ca5ec4a4c4242d0bc2438aa838adebd83e05c4
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       !cancelled() && !failure()
       && !(needs.pre-flight.outputs.docs_only == 'true'
            || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@f680963ed397a4ff0cd4c983a3a3071c209e5e77
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@3c679d436baa0b926766e9b1e6d149803c506b5d
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       !cancelled() && !failure()
       && !(needs.pre-flight.outputs.docs_only == 'true'
            || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.1.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@f680963ed397a4ff0cd4c983a3a3071c209e5e77
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       !cancelled() && !failure()
       && !(needs.pre-flight.outputs.docs_only == 'true'
            || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@3c679d436baa0b926766e9b1e6d149803c506b5d
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@57cc8e1ed81d8a1d83cecb2e4a54e04144623bcf
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: emerging_optimizers


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Companion to **NVIDIA-NeMo/FW-CI-templates#480**, which mirrors the branch-protection rule of `[rv][0-9].[0-9].[0-9]` onto `deploy-release/*` so the validate-only release rehearsal is gated by the same required status checks as a real release.

## Change

Bumps the FW-CI-templates pin in `release.yaml` to commit `042e967e4ac9652c324cbd5b78fd126c089aec6c` (the head of `ko3n1g/feat/mirror-release-branch-protection` on FW-CI-templates).

## What's being validated

After merge of FW-CI-templates#480, a workflow-dispatch of `release.yaml` with `dry-run: true` should:

1. Run the new "Mirror branch protection" step in `bump-next-version`.
2. Update the `deploy-release/*` rule on this repo to match `[rv][0-9].[0-9].[0-9]`.
3. Open the bump PR with `Nemo_CICD_Test` (or the repo's equivalent) shown as a required check.
4. Block merge of the bump until the required checks pass.

## Prerequisites

The `nemo-automation-bot` GitHub App must hold `administration: write` at the org installation, otherwise the mirror step fails the bump.

## Rollout

This PR is **draft + do not merge** — pinned to an unmerged SHA. Once FW-CI-templates#480 lands and ships in a new tag, re-pin to that tag and merge.
</details>
