### PR TITLE
chore: bump version to 0.4.0a0

### DIFF
--- a/emerging_optimizers/package_info.py
+++ b/emerging_optimizers/package_info.py
@@ -14,9 +14,9 @@
 
 
 MAJOR = 0
-MINOR = 3
+MINOR = 4
 PATCH = 0
-PRE_RELEASE = ""
+PRE_RELEASE = "a0"
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)


### PR DESCRIPTION
Bump the package version on `main` from `0.3.0` to `0.4.0a0`, opening the 0.4.x development cycle following the 0.3.0 release.

`emerging_optimizers/package_info.py`: `MINOR` 3 -> 4, `PRE_RELEASE` "" -> "a0". Resolves to `__version__ == "0.4.0a0"`.

Initially used `dev`, but the release bump-next-version workflow only recognizes `rc<N>` / `a<N>` / empty tokens (failed with `Unknown pre-release: dev`). Switched to the alpha token `a0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)