### PR TITLE
Add Muon Cubic5 coefficients

### DIFF
--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -63,7 +63,7 @@ class Muon(OrthogonalizedOptimizer):
     Args:
         {_args_doc}
         coefficient_type: The type of coefficient set to use for the Newton-Schulz iteration. Can be one of
-            ["simple", "quintic", "polar_express", "cans"].
+            ["simple", "quintic", "cubic5", "polar_express", "cans", "aol", "deepseekv4", "custom"].
         num_ns_steps: The number of iteration steps to use in the Newton-Schulz iteration.
         scale_mode: The type of scale factor to use for the update. Defaults to "spectral" style scaling.
         extra_scale_factor: The additional scale factor to use for the update. Setting it to 0.2 can closely match

--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -63,7 +63,7 @@ class Muon(OrthogonalizedOptimizer):
     Args:
         {_args_doc}
         coefficient_type: The type of coefficient set to use for the Newton-Schulz iteration. Can be one of
-            ["simple", "quintic", "cubic5", "polar_express", "cans", "aol", "deepseekv4", "custom"].
+            ["simple", "quintic", "polar_express", "cans", "aol", "deepseekv4", "cubic5", "custom"].
         num_ns_steps: The number of iteration steps to use in the Newton-Schulz iteration.
         scale_mode: The type of scale factor to use for the update. Defaults to "spectral" style scaling.
         extra_scale_factor: The additional scale factor to use for the update. Setting it to 0.2 can closely match

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -207,14 +207,11 @@ def newton_schulz(
     else:
         raise ValueError(f"Invalid coefficient type: {coefficient_type}")
 
-    if coefficient_type == "cubic5" and steps > len(coefficient_sets):
-        logging.warning(
-            "cubic5 is a fixed %d-step schedule, but steps=%d was requested. "
-            "Skipping the extra Newton-Schulz steps.",
-            len(coefficient_sets),
-            steps,
+    if coefficient_type == "cubic5" and steps != len(coefficient_sets):
+        raise ValueError(
+            f"cubic5 is a fixed {len(coefficient_sets)}-step schedule; got steps={steps}. "
+            "Use steps=5, or pass explicit custom coefficients."
         )
-        steps = len(coefficient_sets)
 
     repeat_last_types = ("polar_express", "cans", "deepseekv4")
     iter_mode: CoeffIterMode = "repeat_last" if coefficient_type in repeat_last_types else "cycle"

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -25,7 +25,7 @@ __all__ = ["newton_schulz", "newton_schulz_tp", "NSCoeffT", "get_coefficient_ite
 
 CoeffIterMode = Literal["cycle", "repeat_last"]
 
-NSCoeffT = Literal["simple", "quintic", "polar_express", "cans", "aol", "deepseekv4", "custom"]
+NSCoeffT = Literal["simple", "quintic", "cubic5", "polar_express", "cans", "aol", "deepseekv4", "custom"]
 
 _COEFFICIENT_SETS = {
     # Values are rounded to closest representable in single precision.
@@ -41,6 +41,18 @@ _COEFFICIENT_SETS = {
         (3.7418, -5.5913, 2.3037),
         (2.8769, -3.1427, 1.2046),
         (2.8366, -3.0525, 1.2012),
+    ],
+    "cubic5": [
+        # Relaxed cubic Newton-Schulz schedule for Muon.
+        # Source: https://arxiv.org/abs/2606.00371
+        # The coefficients were optimized for the relaxed singular-value band with
+        # an effective BF16 lower bound l0 = 7e-3.  Setting c=0 selects the cubic
+        # path in the Newton-Schulz step and avoids the Gram-square matmul.
+        (3.3656576, -3.3420992, 0.0),
+        (2.5744352, -1.4957376, 0.0),
+        (2.5368962, -1.4312570, 0.0),
+        (2.4418906, -1.2764040, 0.0),
+        (2.2230472, -0.9630650, 0.0),
     ],
     "polar_express": [
         # Polar Express iteration from: https://arxiv.org/abs/2505.16932
@@ -148,6 +160,7 @@ def newton_schulz(
     Parameter ``coefficient_type`` can be one of the following
       - "simple": Default coefficient set.
       - "quintic": Quintic iteration with optimized coefficients.
+      - "cubic5": Relaxed cubic five-step schedule.
       - "polar_express": Polar Express iteration with optimized coefficients.
       - "cans": CANS iteration with Remez + adaptive interval coefficients.
       - "aol": AOL coefficient set.
@@ -194,7 +207,7 @@ def newton_schulz(
     else:
         raise ValueError(f"Invalid coefficient type: {coefficient_type}")
 
-    repeat_last_types = ("polar_express", "cans", "deepseekv4")
+    repeat_last_types = ("cubic5", "polar_express", "cans", "deepseekv4")
     iter_mode: CoeffIterMode = "repeat_last" if coefficient_type in repeat_last_types else "cycle"
     coeff_iter = get_coefficient_iterator(steps, coefficient_sets, mode=iter_mode)
 
@@ -315,6 +328,8 @@ def newton_schulz_step(
     A = X @ X.mT
     if tp_group is not None:
         torch.distributed.all_reduce(A, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+    if c == 0.0:
+        return torch.addmm(X, A, X, alpha=b, beta=a)
     B = torch.addmm(A, A, A, alpha=c, beta=b)
     X = torch.addmm(X, B, X, alpha=1.0, beta=a)
     return X
@@ -345,6 +360,8 @@ def batched_newton_schulz_step(
     A = X @ X.mT
     if tp_group is not None:
         torch.distributed.all_reduce(A, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+    if c == 0.0:
+        return torch.baddbmm(X, A, X, alpha=b, beta=a)
     B = torch.baddbmm(A, A, A, alpha=c, beta=b)
     X = torch.baddbmm(X, B, X, alpha=1.0, beta=a)
     return X
@@ -373,6 +390,8 @@ def newton_schulz_step_tsyrk(
     A = triton_kernels.tsyrk_ex(X)  # type: ignore[attr-defined]
     if tp_group is not None:
         torch.distributed.all_reduce(A, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+    if c == 0.0:
+        return torch.addmm(X, A, X, alpha=b, beta=a)
     B = triton_kernels.tsyrk_ex(A, A, alpha=c, beta=b)  # type: ignore[attr-defined]
     X = torch.addmm(X, B, X, alpha=1.0, beta=a)
     return X

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -25,7 +25,7 @@ __all__ = ["newton_schulz", "newton_schulz_tp", "NSCoeffT", "get_coefficient_ite
 
 CoeffIterMode = Literal["cycle", "repeat_last"]
 
-NSCoeffT = Literal["simple", "quintic", "cubic5", "polar_express", "cans", "aol", "deepseekv4", "custom"]
+NSCoeffT = Literal["simple", "quintic", "polar_express", "cans", "aol", "deepseekv4", "custom", "cubic5"]
 
 _COEFFICIENT_SETS = {
     # Values are rounded to closest representable in single precision.
@@ -41,18 +41,6 @@ _COEFFICIENT_SETS = {
         (3.7418, -5.5913, 2.3037),
         (2.8769, -3.1427, 1.2046),
         (2.8366, -3.0525, 1.2012),
-    ],
-    "cubic5": [
-        # Relaxed cubic Newton-Schulz schedule for Muon.
-        # Source: https://arxiv.org/abs/2606.00371
-        # The coefficients were optimized for the relaxed singular-value band with
-        # an effective BF16 lower bound l0 = 7e-3.  Setting c=0 selects the cubic
-        # path in the Newton-Schulz step and avoids the Gram-square matmul.
-        (3.3656576, -3.3420992, 0.0),
-        (2.5744352, -1.4957376, 0.0),
-        (2.5368962, -1.4312570, 0.0),
-        (2.4418906, -1.2764040, 0.0),
-        (2.2230472, -0.9630650, 0.0),
     ],
     "polar_express": [
         # Polar Express iteration from: https://arxiv.org/abs/2505.16932
@@ -87,6 +75,18 @@ _COEFFICIENT_SETS = {
     "deepseekv4":
     # From DeepSeekV4: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/resolve/main/DeepSeek_V4.pdf
     [(3.4445, -4.7750, 2.0315)] * 8 + [(2.0, -1.5, 0.5)] * 2,
+    "cubic5": [
+        # Relaxed cubic Newton-Schulz schedule for Muon.
+        # Source: https://arxiv.org/abs/2606.00371
+        # The coefficients were optimized for the relaxed singular-value band with
+        # an effective BF16 lower bound l0 = 7e-3.  Setting c=0 selects the cubic
+        # path in the Newton-Schulz step and avoids the Gram-square matmul.
+        (3.3656576, -3.3420992, 0.0),
+        (2.5744352, -1.4957376, 0.0),
+        (2.5368962, -1.4312570, 0.0),
+        (2.4418906, -1.2764040, 0.0),
+        (2.2230472, -0.9630650, 0.0),
+    ],
 }
 
 
@@ -160,11 +160,11 @@ def newton_schulz(
     Parameter ``coefficient_type`` can be one of the following
       - "simple": Default coefficient set.
       - "quintic": Quintic iteration with optimized coefficients.
-      - "cubic5": Relaxed cubic five-step schedule.
       - "polar_express": Polar Express iteration with optimized coefficients.
       - "cans": CANS iteration with Remez + adaptive interval coefficients.
       - "aol": AOL coefficient set.
       - "deepseekv4": DeepSeekV4 coefficient set.
+      - "cubic5": Relaxed cubic five-step schedule.
       - "custom": Custom coefficient sets.
 
     Arguments:
@@ -207,7 +207,7 @@ def newton_schulz(
     else:
         raise ValueError(f"Invalid coefficient type: {coefficient_type}")
 
-    repeat_last_types = ("cubic5", "polar_express", "cans", "deepseekv4")
+    repeat_last_types = ("polar_express", "cans", "deepseekv4", "cubic5")
     iter_mode: CoeffIterMode = "repeat_last" if coefficient_type in repeat_last_types else "cycle"
     coeff_iter = get_coefficient_iterator(steps, coefficient_sets, mode=iter_mode)
 
@@ -328,10 +328,11 @@ def newton_schulz_step(
     A = X @ X.mT
     if tp_group is not None:
         torch.distributed.all_reduce(A, op=torch.distributed.ReduceOp.SUM, group=tp_group)
-    if c == 0.0:
-        return torch.addmm(X, A, X, alpha=b, beta=a)
-    B = torch.addmm(A, A, A, alpha=c, beta=b)
-    X = torch.addmm(X, B, X, alpha=1.0, beta=a)
+    if c != 0.0:
+        B = torch.baddbmm(A, A, A, alpha=c, beta=b)
+        X = torch.baddbmm(X, B, X, alpha=1.0, beta=a)
+    else:
+        X = torch.baddbmm(X, A, X, alpha=b, beta=a)
     return X
 
 
@@ -360,10 +361,11 @@ def batched_newton_schulz_step(
     A = X @ X.mT
     if tp_group is not None:
         torch.distributed.all_reduce(A, op=torch.distributed.ReduceOp.SUM, group=tp_group)
-    if c == 0.0:
-        return torch.baddbmm(X, A, X, alpha=b, beta=a)
-    B = torch.baddbmm(A, A, A, alpha=c, beta=b)
-    X = torch.baddbmm(X, B, X, alpha=1.0, beta=a)
+    if c != 0.0:
+        B = torch.baddbmm(A, A, A, alpha=c, beta=b)
+        X = torch.baddbmm(X, B, X, alpha=1.0, beta=a)
+    else:
+        X = torch.baddbmm(X, A, X, alpha=b, beta=a)
     return X
 
 
@@ -390,8 +392,9 @@ def newton_schulz_step_tsyrk(
     A = triton_kernels.tsyrk_ex(X)  # type: ignore[attr-defined]
     if tp_group is not None:
         torch.distributed.all_reduce(A, op=torch.distributed.ReduceOp.SUM, group=tp_group)
-    if c == 0.0:
-        return torch.addmm(X, A, X, alpha=b, beta=a)
-    B = triton_kernels.tsyrk_ex(A, A, alpha=c, beta=b)  # type: ignore[attr-defined]
-    X = torch.addmm(X, B, X, alpha=1.0, beta=a)
+    if c != 0.0:
+        B = triton_kernels.tsyrk_ex(A, A, alpha=c, beta=b)  # type: ignore[attr-defined]
+        X = torch.addmm(X, B, X, alpha=1.0, beta=a)
+    else:
+        X = torch.addmm(X, A, X, alpha=b, beta=a)
     return X

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -207,7 +207,16 @@ def newton_schulz(
     else:
         raise ValueError(f"Invalid coefficient type: {coefficient_type}")
 
-    repeat_last_types = ("polar_express", "cans", "deepseekv4", "cubic5")
+    if coefficient_type == "cubic5" and steps > len(coefficient_sets):
+        logging.warning(
+            "cubic5 is a fixed %d-step schedule, but steps=%d was requested. "
+            "Skipping the extra Newton-Schulz steps.",
+            len(coefficient_sets),
+            steps,
+        )
+        steps = len(coefficient_sets)
+
+    repeat_last_types = ("polar_express", "cans", "deepseekv4")
     iter_mode: CoeffIterMode = "repeat_last" if coefficient_type in repeat_last_types else "cycle"
     coeff_iter = get_coefficient_iterator(steps, coefficient_sets, mode=iter_mode)
 
@@ -329,10 +338,10 @@ def newton_schulz_step(
     if tp_group is not None:
         torch.distributed.all_reduce(A, op=torch.distributed.ReduceOp.SUM, group=tp_group)
     if c != 0.0:
-        B = torch.baddbmm(A, A, A, alpha=c, beta=b)
-        X = torch.baddbmm(X, B, X, alpha=1.0, beta=a)
+        B = torch.addmm(A, A, A, alpha=c, beta=b)
+        X = torch.addmm(X, B, X, alpha=1.0, beta=a)
     else:
-        X = torch.baddbmm(X, A, X, alpha=b, beta=a)
+        X = torch.addmm(X, A, X, alpha=b, beta=a)
     return X
 
 

--- a/tests/test_muon_utils.py
+++ b/tests/test_muon_utils.py
@@ -134,6 +134,63 @@ class TestNewtonSchulz(parameterized.TestCase):
         torch.testing.assert_close(out_3d, out_per_slice, atol=1e-6, rtol=0)
 
     @parameterized.parameters(
+        (2, 256, 256),
+        (4, 128, 256),
+        (3, 256, 128),
+    )
+    def test_cubic5_3d_input_close_to_per_slice(self, batch, dim1, dim2):
+        x = torch.randint(-3, 4, (batch, dim1, dim2), device=self.device, dtype=torch.float32)
+        out_3d = muon_utils.newton_schulz(x, steps=5, coefficient_type="cubic5")
+        out_per_slice = torch.stack(
+            [muon_utils.newton_schulz(x[i], steps=5, coefficient_type="cubic5") for i in range(batch)]
+        )
+        torch.testing.assert_close(out_3d, out_per_slice, atol=1e-6, rtol=0)
+
+    @parameterized.parameters(
+        (512, 512),
+        (512, 256),
+        (256, 512),
+    )
+    def test_cubic5_close_to_reference(self, dim1, dim2):
+        x = torch.randn(dim1, dim2, device=self.device, dtype=torch.float32)
+        out_cubic5_test = muon_utils.newton_schulz(x, steps=5, coefficient_type="cubic5")
+        out_cubic5_ref = newton_schulz_ref(x, coefficient_sets=muon_utils._COEFFICIENT_SETS["cubic5"])
+
+        torch.testing.assert_close(
+            out_cubic5_test,
+            out_cubic5_ref,
+            atol=1e-6,
+            rtol=1e-7,
+        )
+
+    @parameterized.product(
+        size=[(511, 513), (511, 257), (257, 513)],
+        steps=[1, 2, 3, 4],
+    )
+    def test_cubic5_prefix_close_to_reference(self, size, steps):
+        dim1, dim2 = size
+        x = torch.randn(dim1, dim2, device=self.device, dtype=torch.float32)
+        out_cubic5_test = muon_utils.newton_schulz(x, steps=steps, coefficient_type="cubic5")
+        out_cubic5_ref = newton_schulz_ref(
+            x,
+            coefficient_sets=muon_utils._COEFFICIENT_SETS["cubic5"][:steps],
+        )
+
+        torch.testing.assert_close(
+            out_cubic5_test,
+            out_cubic5_ref,
+            atol=1e-6,
+            rtol=1e-7,
+        )
+
+    def test_cubic5_too_many_steps_matches_five_step_schedule(self) -> None:
+        x = torch.randn(5, 7, device=self.device, dtype=torch.float32)
+        out_cubic5_6 = muon_utils.newton_schulz(x, steps=6, coefficient_type="cubic5")
+        out_cubic5_5 = muon_utils.newton_schulz(x, steps=5, coefficient_type="cubic5")
+
+        torch.testing.assert_close(out_cubic5_6, out_cubic5_5, atol=0, rtol=0)
+
+    @parameterized.parameters(
         (511, 513),
         (511, 257),
         (257, 513),
@@ -367,6 +424,22 @@ class TestBatchedNewtonSchulzStep(parameterized.TestCase):
         per_item = torch.stack([muon_utils.newton_schulz_step(x[i], a, b, c) for i in range(batch)])
 
         torch.testing.assert_close(batched, per_item, atol=1e-8, rtol=0)
+
+    @parameterized.parameters(
+        (2, 16, 16),
+        (4, 16, 32),
+        (3, 32, 16),
+    )
+    def test_batched_cubic_newton_schulz_step_matches_formula(self, batch, dim1, dim2):
+        x = torch.randint(-3, 4, (batch, dim1, dim2), device=self.device, dtype=torch.float32)
+        x = x / x.norm(dim=(-2, -1), keepdim=True).clamp_min_(1e-7)
+
+        a, b, c = 2.0, -1.5, 0.0
+        test_out = muon_utils.batched_newton_schulz_step(x, a, b, c)
+        gram = x @ x.mT
+        expected = a * x + b * (gram @ x)
+
+        torch.testing.assert_close(test_out, expected, atol=1e-6, rtol=1e-7)
 
 
 @absltest.skipIf(

--- a/tests/test_muon_utils.py
+++ b/tests/test_muon_utils.py
@@ -163,32 +163,11 @@ class TestNewtonSchulz(parameterized.TestCase):
             rtol=1e-7,
         )
 
-    @parameterized.product(
-        size=[(511, 513), (511, 257), (257, 513)],
-        steps=[1, 2, 3, 4],
-    )
-    def test_cubic5_prefix_close_to_reference(self, size, steps):
-        dim1, dim2 = size
-        x = torch.randn(dim1, dim2, device=self.device, dtype=torch.float32)
-        out_cubic5_test = muon_utils.newton_schulz(x, steps=steps, coefficient_type="cubic5")
-        out_cubic5_ref = newton_schulz_ref(
-            x,
-            coefficient_sets=muon_utils._COEFFICIENT_SETS["cubic5"][:steps],
-        )
-
-        torch.testing.assert_close(
-            out_cubic5_test,
-            out_cubic5_ref,
-            atol=1e-6,
-            rtol=1e-7,
-        )
-
-    def test_cubic5_too_many_steps_matches_five_step_schedule(self) -> None:
+    @parameterized.parameters(1, 4, 6)
+    def test_cubic5_wrong_step_count_raises_value_error(self, steps) -> None:
         x = torch.randn(5, 7, device=self.device, dtype=torch.float32)
-        out_cubic5_6 = muon_utils.newton_schulz(x, steps=6, coefficient_type="cubic5")
-        out_cubic5_5 = muon_utils.newton_schulz(x, steps=5, coefficient_type="cubic5")
-
-        torch.testing.assert_close(out_cubic5_6, out_cubic5_5, atol=0, rtol=0)
+        with self.assertRaisesRegex(ValueError, "cubic5.*fixed.*5-step schedule.*steps=5"):
+            muon_utils.newton_schulz(x, steps=steps, coefficient_type="cubic5")
 
     @parameterized.parameters(
         (511, 513),
@@ -430,7 +409,7 @@ class TestBatchedNewtonSchulzStep(parameterized.TestCase):
         (4, 16, 32),
         (3, 32, 16),
     )
-    def test_batched_cubic_newton_schulz_step_matches_formula(self, batch, dim1, dim2):
+    def test_batched_cubic_newton_schulz_step_close_to_formula(self, batch, dim1, dim2):
         x = torch.randint(-3, 4, (batch, dim1, dim2), device=self.device, dtype=torch.float32)
         x = x / x.norm(dim=(-2, -1), keepdim=True).clamp_min_(1e-7)
 


### PR DESCRIPTION
This PR adds a relaxed cubic Newton-Schulz coefficients for Muon. Please refer to https://arxiv.org/abs/2606.00371 for the detailed information, including the construction of the coefficients and model training test results.