### PR TITLE
Change fp32_matmul_prec default to highest in soap

### DIFF
--- a/benchmarks/soap_benchmark.py
+++ b/benchmarks/soap_benchmark.py
@@ -28,6 +28,12 @@ from emerging_optimizers.soap.soap import SOAP
 flags.DEFINE_bool("use_eigh", False, "Use eigh instead of QR iteration.")
 flags.DEFINE_string("dtype", "bfloat16", "Parameter dtype: float32, bfloat16, or float16.")
 flags.DEFINE_integer("num_streams", None, "Number of CUDA streams for SOAP. None means no stream_list.")
+flags.DEFINE_enum(
+    "fp32_matmul_prec",
+    "highest",
+    ["highest", "high", "medium"],
+    "Precision of the matmul operations in optimizer states GEMM operations.",
+)
 
 
 def main(_: Any) -> None:
@@ -65,6 +71,7 @@ def main(_: Any) -> None:
         params,
         lr=0.25,
         use_eigh=FLAGS.use_eigh,
+        fp32_matmul_prec=FLAGS.fp32_matmul_prec,
         stream_list=stream_list,
     )
 

--- a/benchmarks/soap_benchmark.py
+++ b/benchmarks/soap_benchmark.py
@@ -76,8 +76,9 @@ def main(_: Any) -> None:
     )
 
     print("\nSOAP settings:")
-    print(f"  use_eigh    : {FLAGS.use_eigh}")
-    print(f"  num_streams : {FLAGS.num_streams}")
+    print(f"  use_eigh         : {FLAGS.use_eigh}")
+    print(f"  num_streams      : {FLAGS.num_streams}")
+    print(f"  fp32_matmul_prec : {FLAGS.fp32_matmul_prec}")
 
     print(f"\nWarming up ({FLAGS.warmup_steps} steps)...")
     for _ in range(FLAGS.warmup_steps):

--- a/emerging_optimizers/soap/soap.py
+++ b/emerging_optimizers/soap/soap.py
@@ -89,7 +89,7 @@ class SOAP(opt_mixin.WeightDecayMixin, optim.Optimizer):
         weight_decay_method: opt_mixin.WeightDecayT = "decoupled",
         nesterov: bool = False,
         correct_bias: bool = True,
-        fp32_matmul_prec: FP32MatmulPrecT = "high",
+        fp32_matmul_prec: FP32MatmulPrecT = "highest",
         use_eigh: bool = False,
         qr_fp32_matmul_prec: FP32MatmulPrecT = "high",
         power_iter_steps: int = 1,


### PR DESCRIPTION
When there is a sudden gradient spike, it can cause Kronecker factors to be ill conditioned. 

Offline experiments showed that subsequent eigen value approximation in KL shampoo needs more than 10bit mantissa that TF32 can offer. FP32 seems to be safe enough.

Also updated soap benchmark to have the argument. Performance impact is negligible because majority of the time is spent on QR or eigen decomposition.
