### PR TITLE
Add option to normalize NS input in double precision

### DIFF
--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -190,7 +190,8 @@ def newton_schulz(
         use_syrk: Whether to use the Triton kernel for the Newton-Schulz iteration.
         normalize_in_double: Whether to reduce the Frobenius norm in float64. This keeps the squared
             sum out of float32 underflow for inputs with very small entries, at the cost of a float64
-            reduction.
+            reduction. Without customized kernels, manually handle scaling without triggering a device to host
+            sync are usually more expensive than using double.
 
     Returns:
         The orthogonalization of x.

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import math
 from itertools import chain, cycle, islice, repeat
 from typing import Any, Iterator, Literal, Sequence
 
@@ -130,10 +131,18 @@ def get_coefficient_iterator(
 
 
 def distributed_normalize_p2(x: torch.Tensor, eps: float, group: torch.distributed.ProcessGroup) -> torch.Tensor:
-    """Normalize a tensor in a distributed way."""
+    """Normalize a tensor by its distributed Frobenius norm."""
     x_sq_sum = (x * x).sum()
     torch.distributed.all_reduce(x_sq_sum, op=torch.distributed.ReduceOp.SUM, group=group)
-    return x / torch.sqrt(x_sq_sum).clamp_min(eps)
+    norm = torch.sqrt(x_sq_sum)
+    if norm < eps:
+        shift = torch.ceil(torch.where(norm > 0, torch.log2(eps / norm), math.log2(1 / eps)))
+        x = x * torch.exp2(shift)
+        x_sq_sum = (x * x).sum()
+        torch.distributed.all_reduce(x_sq_sum, op=torch.distributed.ReduceOp.SUM, group=group)
+        norm = torch.sqrt(x_sq_sum)
+        assert norm > 0  # Fail if it still underflows
+    return x / norm
 
 
 def newton_schulz(
@@ -192,13 +201,19 @@ def newton_schulz(
     if transpose:
         x = x.mT
 
-    # Ensure spectral norm is at most 1.
-    # NOTE: ``eps`` is a divide-by-zero guard; it must stay well below any realistic ``||x||_F``
-    # yet remain fp32-safe when squared. See issue #229.
+    # Ensure spectral norm is at most 1 by normalizing with the Frobenius norm.
+    # When the norm is below ``eps`` (or has underflowed to 0 because ``x``'s entries are tiny),
+    # we try to scale it to close to eps value.
     if tp_group is not None:
         X = distributed_normalize_p2(x, eps, tp_group)
     else:
-        X = torch.nn.functional.normalize(x, p=2, dim=(-2, -1), eps=eps)  # type: ignore[arg-type]
+        norm = torch.linalg.vector_norm(x, dim=(-2, -1), keepdim=True)
+        if (norm < eps).any():
+            shift = torch.ceil(torch.where(norm > 0, torch.log2(eps / norm), math.log2(1 / eps)))
+            x = x * torch.exp2(shift)
+            norm = torch.linalg.vector_norm(x, dim=(-2, -1), keepdim=True)
+            assert (norm > 0).all()  # assert if it still underflows
+        X = x / norm
 
     if coefficient_type in _COEFFICIENT_SETS:
         coefficient_sets = _COEFFICIENT_SETS[coefficient_type]

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -215,7 +215,7 @@ def newton_schulz(
         if not normalize_in_double:
             X = torch.nn.functional.normalize(x, p=2, dim=(-2, -1), eps=eps)  # type: ignore[arg-type]
         else:
-            logging.warning("eps is ignored when normalize in double.")
+            # eps is ignored when normalize in double.
             norm = torch.linalg.vector_norm(x, dim=(-2, -1), keepdim=True, dtype=torch.float64).to(x.dtype)
             X = x / norm
 

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -142,7 +142,7 @@ def distributed_normalize_p2(
     torch.distributed.all_reduce(x_sq_sum, op=torch.distributed.ReduceOp.SUM, group=group)
     norm = torch.sqrt(x_sq_sum).to(x.dtype)
     if not normalize_in_double:
-        norm.clamp_min(eps)
+        norm.clamp_min_(eps)
     return x / norm
 
 

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import math
 from itertools import chain, cycle, islice, repeat
 from typing import Any, Iterator, Literal, Sequence
 
@@ -130,18 +129,20 @@ def get_coefficient_iterator(
     return islice(base, steps)
 
 
-def distributed_normalize_p2(x: torch.Tensor, eps: float, group: torch.distributed.ProcessGroup) -> torch.Tensor:
-    """Normalize a tensor by its distributed Frobenius norm."""
-    x_sq_sum = (x * x).sum()
+def distributed_normalize_p2(
+    x: torch.Tensor, eps: float, group: torch.distributed.ProcessGroup, normalize_in_double: bool = False
+) -> torch.Tensor:
+    """Normalize a tensor by its distributed Frobenius norm.
+
+    When ``normalize_in_double`` is set, the squared sum is accumulated in float64 so that tiny
+    entries do not underflow to zero when squared in float32.
+    """
+    x_sq = x.double() if normalize_in_double else x
+    x_sq_sum = (x_sq * x_sq).sum()
     torch.distributed.all_reduce(x_sq_sum, op=torch.distributed.ReduceOp.SUM, group=group)
-    norm = torch.sqrt(x_sq_sum)
-    if norm < eps:
-        shift = torch.ceil(torch.where(norm > 0, torch.log2(eps / norm), math.log2(1 / eps)))
-        x = x * torch.exp2(shift)
-        x_sq_sum = (x * x).sum()
-        torch.distributed.all_reduce(x_sq_sum, op=torch.distributed.ReduceOp.SUM, group=group)
-        norm = torch.sqrt(x_sq_sum)
-        assert norm > 0  # Fail if it still underflows
+    norm = torch.sqrt(x_sq_sum).to(x.dtype)
+    if not normalize_in_double:
+        norm.clamp_min(eps)
     return x / norm
 
 
@@ -154,6 +155,7 @@ def newton_schulz(
     transpose: bool | None = None,
     tp_group: torch.distributed.ProcessGroup | None = None,
     use_syrk: bool = False,
+    normalize_in_double: bool = False,
 ) -> torch.Tensor:
     """Use Newton-Schulz iteration to compute the zeroth power / orthogonalization of x.
 
@@ -186,6 +188,9 @@ def newton_schulz(
             If None, will be determined based on the size of the tensor.
         tp_group: The process group for communication if input is distributed.
         use_syrk: Whether to use the Triton kernel for the Newton-Schulz iteration.
+        normalize_in_double: Whether to reduce the Frobenius norm in float64. This keeps the squared
+            sum out of float32 underflow for inputs with very small entries, at the cost of a float64
+            reduction.
 
     Returns:
         The orthogonalization of x.
@@ -201,19 +206,17 @@ def newton_schulz(
     if transpose:
         x = x.mT
 
-    # Ensure spectral norm is at most 1 by normalizing with the Frobenius norm.
-    # When the norm is below ``eps`` (or has underflowed to 0 because ``x``'s entries are tiny),
-    # we try to scale it to close to eps value.
+    # Ensure spectral norm is at most 1 by normalizing with the Frobenius norm. Reducing in float64
+    # (``normalize_in_double``) keeps the squared sum out of float32 underflow for tiny-norm inputs.
     if tp_group is not None:
-        X = distributed_normalize_p2(x, eps, tp_group)
+        X = distributed_normalize_p2(x, eps, tp_group, normalize_in_double)
     else:
-        norm = torch.linalg.vector_norm(x, dim=(-2, -1), keepdim=True)
-        if (norm < eps).any():
-            shift = torch.ceil(torch.where(norm > 0, torch.log2(eps / norm), math.log2(1 / eps)))
-            x = x * torch.exp2(shift)
-            norm = torch.linalg.vector_norm(x, dim=(-2, -1), keepdim=True)
-            assert (norm > 0).all()  # assert if it still underflows
-        X = x / norm
+        if not normalize_in_double:
+            X = torch.nn.functional.normalize(x, p=2, dim=(-2, -1), eps=eps)  # type: ignore[arg-type]
+        else:
+            logging.warning("eps is ignored when normalize in double.")
+            norm = torch.linalg.vector_norm(x, dim=(-2, -1), keepdim=True, dtype=torch.float64).to(x.dtype)
+            X = x / norm
 
     if coefficient_type in _COEFFICIENT_SETS:
         coefficient_sets = _COEFFICIENT_SETS[coefficient_type]

--- a/tests/test_muon_utils.py
+++ b/tests/test_muon_utils.py
@@ -125,16 +125,16 @@ class TestNewtonSchulz(parameterized.TestCase):
     def test_normalization_scale_invariant(self, exp2):
         x = torch.randn(256, 256, device=self.device, dtype=torch.float32)
         ref = muon_utils.newton_schulz(x, steps=0, eps=0)
-        out = muon_utils.newton_schulz(2**exp2 * x, steps=0, eps=1e-15)
+        out = muon_utils.newton_schulz(2**exp2 * x, steps=0, eps=0, normalize_in_double=True)
         assert_equal(ref, out)
 
-    def test_preserve_values_with_underflowed_norm(self):
+    def test_preserve_values_with_underflowed_norm_in_fp64(self):
         scale = 1e-30
         x = torch.randn(256, 256, device=self.device, dtype=torch.float32) * scale
         assert torch.linalg.vector_norm(x) == 0  # should underflow
         norm_ref = torch.linalg.vector_norm(x, dtype=torch.double)
         assert norm_ref != 0
-        out = muon_utils.newton_schulz(x, steps=0)
+        out = muon_utils.newton_schulz(x, steps=0, normalize_in_double=True)
         torch.testing.assert_close(x / norm_ref, out, atol=0, rtol=1e-6)
 
     @parameterized.parameters(

--- a/tests/test_muon_utils.py
+++ b/tests/test_muon_utils.py
@@ -121,28 +121,21 @@ class TestNewtonSchulz(parameterized.TestCase):
             rtol=1e-7,
         )
 
-    @parameterized.parameters(1e-2, 1e-6, 1e-9, 1e-12)
-    def test_newtonschulz_small_eps(self, scale):
-        """Orthogonalization depends only on direction, so scaling the input must not change the output.
-
-        Regression test for issue #229: a too-large ``eps`` in the internal ``F.normalize`` divides
-        small-norm inputs by ``eps`` instead of their norm, silently degenerating the output. The
-        orthogonalized result for ``x`` and ``scale * x`` must match for any ``scale > 0``.
-        """
+    @parameterized.parameters(-20, -40, -60)
+    def test_normalization_scale_invariant(self, exp2):
         x = torch.randn(256, 256, device=self.device, dtype=torch.float32)
-        x = x / x.norm()  # unit Frobenius norm direction
-        ref = muon_utils.newton_schulz(x, steps=5, coefficient_type="quintic")
-        out = muon_utils.newton_schulz(scale * x, steps=5, coefficient_type="quintic")
-        torch.testing.assert_close(
-            out,
-            ref,
-            atol=1e-4,
-            rtol=1e-5,
-            msg=lambda m: (
-                f"newton_schulz not scale-invariant at input scale {scale}: "
-                f"||out||_F={out.norm().item():.4f} vs ||ref||_F={ref.norm().item():.4f}\n{m}"
-            ),
-        )
+        ref = muon_utils.newton_schulz(x, steps=0, eps=0)
+        out = muon_utils.newton_schulz(2**exp2 * x, steps=0, eps=1e-15)
+        assert_equal(ref, out)
+
+    def test_preserve_values_with_underflowed_norm(self):
+        scale = 1e-30
+        x = torch.randn(256, 256, device=self.device, dtype=torch.float32) * scale
+        assert torch.linalg.vector_norm(x) == 0  # should underflow
+        norm_ref = torch.linalg.vector_norm(x, dtype=torch.double)
+        assert norm_ref != 0
+        out = muon_utils.newton_schulz(x, steps=0)
+        torch.testing.assert_close(x / norm_ref, out, atol=0, rtol=1e-7)
 
     @parameterized.parameters(
         (2, 256, 256),

--- a/tests/test_muon_utils.py
+++ b/tests/test_muon_utils.py
@@ -121,13 +121,6 @@ class TestNewtonSchulz(parameterized.TestCase):
             rtol=1e-7,
         )
 
-    @parameterized.parameters(-20, -40, -60)
-    def test_normalization_scale_invariant(self, exp2):
-        x = torch.randn(256, 256, device=self.device, dtype=torch.float32)
-        ref = muon_utils.newton_schulz(x, steps=0, eps=0)
-        out = muon_utils.newton_schulz(2**exp2 * x, steps=0, eps=0, normalize_in_double=True)
-        assert_equal(ref, out)
-
     def test_preserve_values_with_underflowed_norm_in_fp64(self):
         scale = 1e-30
         x = torch.randn(256, 256, device=self.device, dtype=torch.float32) * scale

--- a/tests/test_muon_utils.py
+++ b/tests/test_muon_utils.py
@@ -135,7 +135,7 @@ class TestNewtonSchulz(parameterized.TestCase):
         norm_ref = torch.linalg.vector_norm(x, dtype=torch.double)
         assert norm_ref != 0
         out = muon_utils.newton_schulz(x, steps=0)
-        torch.testing.assert_close(x / norm_ref, out, atol=0, rtol=1e-7)
+        torch.testing.assert_close(x / norm_ref, out, atol=0, rtol=1e-6)
 
     @parameterized.parameters(
         (2, 256, 256),


### PR DESCRIPTION
"if" clause on calculated norm would trigger device to host sync, trying to do it on device will take multiple path, in which case none of them are better than just use double. A custom kernel can do it but is out of scope.

No zero division guard for fp64 path as we don't imagine a case that LLM training is done in fp64. Square of fp32 value won't underflow fp64.