### PR TITLE
Forward use_syrk through newton_schulz_tp

### DIFF
--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -253,6 +253,7 @@ def newton_schulz_tp(
     tp_group: torch.distributed.ProcessGroup,
     partition_dim: int | None = None,
     tp_mode: Literal["duplicated", "distributed"] = "duplicated",
+    use_syrk: bool = False,
 ) -> torch.Tensor:
     """Tensor Parallel Newton-Schulz iteration.
 
@@ -280,14 +281,18 @@ def newton_schulz_tp(
         partition_dim: The dimension to partition the tensor.
         tp_group: The process group for communication if input is distributed.
         tp_mode: The mode to use for the Newton-Schulz iteration.
+        use_syrk: Whether to use the Triton SYRK kernel for the Newton-Schulz iteration. Forwarded to the
+            underlying ``newton_schulz`` in every path (non-TP fallback, ``duplicated``, ``distributed``); it only
+            takes effect when the fp32 matmul precision is ``"medium"`` (see ``newton_schulz``).
     """
     if partition_dim is None:
         # Fallback path for non TP params.
-        return newton_schulz(x, steps, coefficient_type)
+        return newton_schulz(x, steps, coefficient_type, use_syrk=use_syrk)
 
     kwargs: Any = {
         "steps": steps,
         "coefficient_type": coefficient_type,
+        "use_syrk": use_syrk,
     }
 
     if tp_mode == "duplicated":

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -284,6 +284,8 @@ def newton_schulz_tp(
         use_syrk: Whether to use the Triton SYRK kernel for the Newton-Schulz iteration. Forwarded to the
             underlying ``newton_schulz`` in every path (non-TP fallback, ``duplicated``, ``distributed``); it only
             takes effect when the fp32 matmul precision is ``"medium"`` (see ``newton_schulz``).
+            Requires both matrix dimensions to be multiples of 8 (16-byte stride alignment for bf16/fp32);
+            weights with unaligned shapes will raise an ``AssertionError`` inside ``tsyrk_ex``.
     """
     if partition_dim is None:
         # Fallback path for non TP params.


### PR DESCRIPTION
Passing use_syrk argument to newton_schulz_tp. Megatron only uses the tp version even if tp is not used (by passing None to tp_group). In order for megatron to use syrk kernels, the argument needs to be exposed.

Low risk change. Merge without test to save time.

