### PR TITLE
fix(syrk): fall back to GEMM Newton-Schulz for non-16B-aligned matrices

### DIFF
--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -249,7 +249,19 @@ def newton_schulz(
         if use_syrk:
             if X.ndim > 2:
                 raise TypeError("use_syrk does not support N-d input.")
-            ns_step_fn = newton_schulz_step_tsyrk
+            # The SYRK Triton kernel uses TMA TensorDescriptors, which require 16-byte-aligned row
+            # strides, i.e. both matrix dims must be multiples of 8 for bf16. Unaligned shapes (e.g.
+            # DeepSeek-V4 Hyper-Connections weights with dim=num_residual_streams=4, whose (4, 4)
+            # product has an 8-byte row stride) would raise "strides must be 16-byte aligned"; keep
+            # the plain GEMM Newton-Schulz step instead.
+            if X.size(-1) % 8 == 0 and X.size(-2) % 8 == 0:
+                ns_step_fn = newton_schulz_step_tsyrk
+            else:
+                logging.log_first_n(
+                    logging.WARNING,
+                    f"[SYRK-SKIP] non-8-aligned shape {tuple(X.shape)}; using GEMM Newton-Schulz.",
+                    8,
+                )
         X = X.to(torch.bfloat16)
         logging.log_first_n(logging.INFO, "Using BF16 I/O kernels for Newton-Schulz iteration.", 1)
 

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -259,8 +259,9 @@ def newton_schulz(
             else:
                 logging.log_first_n(
                     logging.WARNING,
-                    f"[SYRK-SKIP] non-8-aligned shape {tuple(X.shape)}; using GEMM Newton-Schulz.",
+                    "[SYRK-SKIP] non-8-aligned shape %s; using GEMM Newton-Schulz.",
                     8,
+                    tuple(X.shape),
                 )
         X = X.to(torch.bfloat16)
         logging.log_first_n(logging.INFO, "Using BF16 I/O kernels for Newton-Schulz iteration.", 1)

--- a/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon_utils.py
@@ -249,17 +249,13 @@ def newton_schulz(
         if use_syrk:
             if X.ndim > 2:
                 raise TypeError("use_syrk does not support N-d input.")
-            # The SYRK Triton kernel uses TMA TensorDescriptors, which require 16-byte-aligned row
-            # strides, i.e. both matrix dims must be multiples of 8 for bf16. Unaligned shapes (e.g.
-            # DeepSeek-V4 Hyper-Connections weights with dim=num_residual_streams=4, whose (4, 4)
-            # product has an 8-byte row stride) would raise "strides must be 16-byte aligned"; keep
-            # the plain GEMM Newton-Schulz step instead.
             if X.size(-1) % 8 == 0 and X.size(-2) % 8 == 0:
                 ns_step_fn = newton_schulz_step_tsyrk
             else:
                 logging.log_first_n(
-                    logging.WARNING,
-                    "[SYRK-SKIP] non-8-aligned shape %s; using GEMM Newton-Schulz.",
+                    logging.ERROR,
+                    "[SYRK-SKIP] skipping SYRK for shape %s because GEMM M or N is not 16-byte "
+                    "aligned, which is incompatible with TMA.",
                     8,
                     tuple(X.shape),
                 )
@@ -316,8 +312,7 @@ def newton_schulz_tp(
         use_syrk: Whether to use the Triton SYRK kernel for the Newton-Schulz iteration. Forwarded to the
             underlying ``newton_schulz`` in every path (non-TP fallback, ``duplicated``, ``distributed``); it only
             takes effect when the fp32 matmul precision is ``"medium"`` (see ``newton_schulz``).
-            Requires both matrix dimensions to be multiples of 8 (16-byte stride alignment for bf16/fp32);
-            weights with unaligned shapes will raise an ``AssertionError`` inside ``tsyrk_ex``.
+            Falls back to GEMM when either matrix dimension is not a multiple of 8.
     """
     if partition_dim is None:
         # Fallback path for non TP params.

--- a/tests/test_muon_utils.py
+++ b/tests/test_muon_utils.py
@@ -353,6 +353,49 @@ class TestNewtonSchulz(parameterized.TestCase):
         with utils.fp32_matmul_precision("medium"), self.assertRaisesRegex(TypeError, "use_syrk does not support"):
             muon_utils.newton_schulz(x, steps=5, coefficient_type="quintic", use_syrk=True)
 
+    @parameterized.parameters(
+        (4, 4),
+        (4, 8),
+        (8, 4),
+    )
+    def test_newton_schulz_use_syrk_falls_back_for_non_8_aligned_shape(self, dim1, dim2) -> None:
+        """Test that use_syrk falls back to GEMM for shapes that cannot satisfy bf16 TMA alignment."""
+        x = torch.randn(dim1, dim2, device=self.device, dtype=torch.float32)
+        gemm_call_count = 0
+        original_gemm_step = muon_utils.newton_schulz_step
+        original_tsyrk_step = muon_utils.newton_schulz_step_tsyrk
+
+        def record_gemm_call(
+            X: torch.Tensor,
+            a: float,
+            b: float,
+            c: float,
+            tp_group: torch.distributed.ProcessGroup | None = None,
+        ) -> torch.Tensor:
+            nonlocal gemm_call_count
+            gemm_call_count += 1
+            return original_gemm_step(X, a, b, c, tp_group=tp_group)
+
+        def fail_if_called(
+            X: torch.Tensor,
+            a: float,
+            b: float,
+            c: float,
+            tp_group: torch.distributed.ProcessGroup | None = None,
+        ) -> torch.Tensor:
+            raise AssertionError("SYRK step should not be called for non-8-aligned shape")
+
+        try:
+            muon_utils.newton_schulz_step = record_gemm_call
+            muon_utils.newton_schulz_step_tsyrk = fail_if_called
+            with utils.fp32_matmul_precision("medium"):
+                muon_utils.newton_schulz(x, steps=1, coefficient_type="simple", use_syrk=True)
+        finally:
+            muon_utils.newton_schulz_step = original_gemm_step
+            muon_utils.newton_schulz_step_tsyrk = original_tsyrk_step
+
+        self.assertEqual(gemm_call_count, 1)
+
 
 class TestMuonUtils(parameterized.TestCase):
     def setUp(self):


### PR DESCRIPTION
SYRK's `tsyrk_ex` uses TMA descriptors requiring 16-byte-aligned strides, so both matrix dims must be multiples of 8; unaligned weights (e.g. DSv4 MHC `(4, N)`) assert "strides must be 16-byte aligned".
Guard the `newton_schulz` SYRK dispatch to take the TMA path only when both dims are multiples of 8, otherwise fall back to the plain GEMM Newton-Schulz step.
