### PR TITLE
Add left polargrad function

### DIFF
--- a/docs/apidocs/orthogonalized-optimizers.md
+++ b/docs/apidocs/orthogonalized-optimizers.md
@@ -46,6 +46,8 @@ emerging_optimizers.orthogonalized_optimizers
 .. autoclass:: PolarGrad
     :members:
 
+.. autofunction:: left_polargrad_orth_fn
+
 .. autofunction:: right_polargrad_orth_fn
 
 

--- a/emerging_optimizers/orthogonalized_optimizers/polargrad.py
+++ b/emerging_optimizers/orthogonalized_optimizers/polargrad.py
@@ -26,7 +26,7 @@ from emerging_optimizers.utils import FP32MatmulPrecT
 from emerging_optimizers.utils.eig import eigh_with_fallback
 
 
-__all__ = ["PolarGrad", "right_polargrad_orth_fn"]
+__all__ = ["PolarGrad", "left_polargrad_orth_fn", "right_polargrad_orth_fn"]
 
 
 @registry.register_optimizer("polargrad")
@@ -170,6 +170,88 @@ def right_polargrad_orth_fn(
     right_gram_inv_sqrt = (eigvecs * eigvals.rsqrt().unsqueeze(-2)) @ eigvecs.transpose(-1, -2)
 
     u = m @ right_gram_inv_sqrt
+    nuclear_norm = eigvals.sqrt().sum()
+    update = u * nuclear_norm.pow(alpha) * extra_scale_factor
+
+    if center_rows:
+        update = update - update.mean(dim=0, keepdim=True)
+    return update.to(grad.dtype)
+
+
+def left_polargrad_orth_fn(
+    grad: torch.Tensor,
+    *,
+    alpha: float = 1.0,
+    center_rows: bool = False,
+    eps: float = 1e-15,
+    extra_scale_factor: float = 1.0,
+) -> torch.Tensor:
+    r"""Left-spectral (one-sided polar) orthogonalization for wide matrices.
+
+    Orthogonalizes only the left factor of a wide matrix ``G`` (e.g. an MoE router weight,
+    ``num_experts x hidden``):
+
+    .. math::
+        u = (G \, G^\top)^{-1/2} \, G, \qquad \text{update} = \lVert G \rVert_*^{\,\alpha} \, u
+
+    .. code-block:: python
+       :caption: Define a ``LeftPolarGrad`` by partially applying this orthogonalization
+
+       class LeftPolarGrad(OrthogonalizedOptimizer):
+           def __init__(
+               self,
+               params,
+               lr: float = 3e-4,
+               momentum: float = 0.95,
+               weight_decay: float = 0.01,
+               *,
+               ...
+               alpha: float = 1.0,
+               center_rows: bool = False,
+               eps: float = 1e-15,
+               extra_scale_factor: float = 1.0,
+           ) -> None:
+               scaled_orthogonalize_fn = functools.partial(
+                   left_polargrad_orth_fn,
+                   alpha=alpha,
+                   center_rows=center_rows,
+                   eps=eps,
+                   extra_scale_factor=extra_scale_factor,
+               )
+               super().__init__(
+                   ...
+               )
+
+    Note:
+        The inverse square root is computed as a pseudo-inverse: eigendirections of the left Gram that
+        are numerically indistinguishable from its null space contribute nothing to the update instead
+        of being amplified by the ``eps`` floor. This matters because the left Gram is singular whenever
+        ``center_rows=True`` (centering annihilates the all-ones direction) or the matrix has more rows
+        than columns.
+
+    Args:
+        grad: The (momentum) tensor to orthogonalize.
+        alpha: Exponent applied to the nuclear-norm scale factor.
+        center_rows: If True, subtract the per-column mean (the average over the row / expert axis,
+            ``dim=0``) before and after the update, so each column is zero-mean. For MoE routers this
+            respects the logit-shift invariance of the routing softmax.
+        eps: Floor on the left-Gram eigenvalues for the nuclear-norm computation.
+        extra_scale_factor: Extra multiplier on the update.
+
+    Returns:
+        The scaled left-polar update, same shape and dtype as ``grad``.
+    """
+    m = grad.to(torch.float32)
+    if center_rows:
+        m = m - m.mean(dim=0, keepdim=True)
+
+    eigvals, eigvecs = eigh_with_fallback(m @ m.transpose(-1, -2))
+    eigvals.clamp_min_(eps)
+    cutoff = eigvals.amax() * m.shape[-2] * torch.finfo(torch.float32).eps
+    inv_sqrt_eigvals = torch.where(eigvals > cutoff, eigvals.rsqrt(), torch.zeros_like(eigvals))
+    left_gram_inv_sqrt = (eigvecs * inv_sqrt_eigvals.unsqueeze(-2)) @ eigvecs.transpose(-1, -2)
+
+    u = left_gram_inv_sqrt @ m
     nuclear_norm = eigvals.sqrt().sum()
     update = u * nuclear_norm.pow(alpha) * extra_scale_factor
 

--- a/tests/test_polargrad.py
+++ b/tests/test_polargrad.py
@@ -128,5 +128,73 @@ class RightPolarGradOrthFnTest(parameterized.TestCase):
         self.assertTrue(torch.isfinite(param).all())
 
 
+class LeftPolarGradOrthFnTest(parameterized.TestCase):
+    def setUp(self):
+        self.device = FLAGS.device
+
+    @parameterized.parameters((4, 8), (8, 32))
+    def test_left_orthogonal_equivariance(self, num_rows, num_cols) -> None:
+        """f(Q G) == Q f(G) for an orthogonal Q acting on the row (left) dimension."""
+        grad = torch.randn((num_rows, num_cols), device=self.device)
+        q, _ = torch.linalg.qr(torch.randn(num_rows, num_rows, device=self.device))
+
+        rotated = polargrad.left_polargrad_orth_fn(q @ grad)
+        expected = q @ polargrad.left_polargrad_orth_fn(grad)
+        torch.testing.assert_close(
+            rotated,
+            expected,
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    @parameterized.product(shape=[(4, 8), (8, 32)], center_rows=[False, True])
+    def test_row_permutation_equivariance(self, shape, center_rows) -> None:
+        """f(P G) == P f(G) for a permutation P of the rows (e.g. MoE expert permutation)."""
+        grad = torch.randn(shape, device=self.device)
+        perm = torch.randperm(shape[0], device=self.device)
+
+        permuted = polargrad.left_polargrad_orth_fn(grad[perm], center_rows=center_rows)
+        expected = polargrad.left_polargrad_orth_fn(grad, center_rows=center_rows)[perm]
+        atol, rtol = (1e-2, 1e-3) if center_rows else (1e-4, 1e-4)
+        torch.testing.assert_close(
+            permuted,
+            expected,
+            atol=atol,
+            rtol=rtol,
+        )
+
+    @parameterized.parameters((4, 8), (8, 32))
+    def test_center_rows_output_is_centered(self, num_rows, num_cols) -> None:
+        """With center_rows=True the update stays in the zero-column-mean quotient subspace."""
+        grad = torch.randn((num_rows, num_cols), device=self.device)
+        update = polargrad.left_polargrad_orth_fn(grad, center_rows=True)
+        torch.testing.assert_close(
+            update.mean(dim=0),
+            torch.zeros(num_cols, device=self.device),
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+    def test_usable_as_scaled_orthogonalize_fn(self) -> None:
+        param = nn.Parameter(torch.randn((8, 32), device=self.device))
+        scaled_orthogonalize_fn = functools.partial(
+            polargrad.left_polargrad_orth_fn, alpha=1.0, center_rows=True, extra_scale_factor=0.2
+        )
+        opt = OrthogonalizedOptimizer(
+            [param],
+            lr=1e-2,
+            momentum=0.95,
+            weight_decay=0.01,
+            nesterov=False,
+            weight_decay_method="decoupled",
+            fp32_matmul_prec="highest",
+            scaled_orthogonalize_fn=scaled_orthogonalize_fn,
+        )
+        for _ in range(3):
+            param.grad = torch.randn_like(param)
+            opt.step()
+        self.assertTrue(torch.isfinite(param).all())
+
+
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
## What does this PR do?

Adds `left_polargrad_orth_fn`, the left-spectral counterpart of `right_polargrad_orth_fn` (#234), as a follow-up to #188:

$$u = (G G^\top)^{-1/2} G, \qquad \text{update} = \lVert G \rVert_*^{\alpha} \, u$$

Intended for wide matrices such as MoE router weights (`num_experts x hidden`), where `center_rows=True` respects expert-permutation symmetry and the logit-shift invariance of the routing softmax. Same shape as #234: a composable orthogonalization function plus a docstring example of building an optimizer from it, no new optimizer class and no new arguments.

## Why the inverse sqrt uses a pseudo-inverse cutoff

With `center_rows=True` the left Gram $G G^\top$ is always exactly singular: centering annihilates the all-ones direction. Mirroring the right variant's `clamp_min(eps).rsqrt()` there turns eigh noise on the null eigenvalue into ~`eps^{-1/2}` amplification; across 600 randomized fp32 trials the worst spurious error in the permutation-equivariance check was ~3.5e2, on the order of the update itself. The right variant does not hit this because its Gram stays full-rank for tall inputs.

This implementation drops eigendirections below `eigvals.amax() * nrows * fp32_eps` instead. On the same 600 trials the worst error becomes 3.2e-3 (2e-4 relative), results on full-rank inputs are bit-identical to the clamp formula, and the same treatment covers uncentered inputs with more rows than columns.

## Tests

Mirrors the #234 test style:

- Left-orthogonal equivariance `f(QG) = Q f(G)`.
- Row-permutation equivariance with and without `center_rows`. Centering only commutes with transformations that fix the all-ones vector, so the centered case is tested with permutations rather than general orthogonal matrices, and uses looser tolerances (fp32 eigh noise on the singular Gram dominates the comparison).
- Centered updates keep zero column means.
- Composition through `OrthogonalizedOptimizer.step()`.

Verified locally: `test_polargrad.py` and `test_orthogonalized_optimizer.py` pass on `--device=cpu` and `--device=cuda`, random seed and `--seed=42`; mypy and pre-commit clean.
