### PR TITLE
Consolidate left/right polargrad into one function

### DIFF
--- a/docs/apidocs/orthogonalized-optimizers.md
+++ b/docs/apidocs/orthogonalized-optimizers.md
@@ -46,6 +46,8 @@ emerging_optimizers.orthogonalized_optimizers
 .. autoclass:: PolarGrad
     :members:
 
+.. autofunction:: one_sided_polargrad_orth_fn
+
 .. autofunction:: left_polargrad_orth_fn
 
 .. autofunction:: right_polargrad_orth_fn

--- a/emerging_optimizers/orthogonalized_optimizers/polargrad.py
+++ b/emerging_optimizers/orthogonalized_optimizers/polargrad.py
@@ -129,49 +129,12 @@ def one_sided_polargrad_orth_fn(
     ``side="right"`` suits tall matrices (e.g. an embedding or LM-head weight, ``vocab x hidden``);
     ``side="left"`` suits wide matrices (e.g. an MoE router weight, ``num_experts x hidden``).
 
-    .. code-block:: python
-       :caption: Define a ``LeftPolarGrad`` by partially applying this orthogonalization
-
-       class LeftPolarGrad(OrthogonalizedOptimizer):
-           def __init__(
-               self,
-               params,
-               lr: float = 3e-4,
-               momentum: float = 0.95,
-               weight_decay: float = 0.01,
-               *,
-               ...
-               alpha: float = 1.0,
-               center_rows: bool = False,
-               eps: float = 1e-15,
-               extra_scale_factor: float = 1.0,
-           ) -> None:
-               scaled_orthogonalize_fn = functools.partial(
-                   one_sided_polargrad_orth_fn,
-                   side="left",
-                   alpha=alpha,
-                   center_rows=center_rows,
-                   eps=eps,
-                   extra_scale_factor=extra_scale_factor,
-               )
-               super().__init__(
-                   ...
-               )
-
-    Note:
-        The inverse square root is computed as a pseudo-inverse: eigendirections of the Gram matrix that
-        are numerically indistinguishable from its null space contribute nothing to the update instead
-        of being amplified by the ``eps`` floor. This matters because the Gram is singular whenever
-        ``center_rows=True`` on the ``side="left"`` Gram (centering annihilates the all-ones direction)
-        or the matrix is rank deficient.
-
     Args:
         grad: The (momentum) tensor to orthogonalize.
         side: Which polar factor to orthogonalize, ``"left"`` or ``"right"``.
         alpha: Exponent applied to the nuclear-norm scale factor.
         center_rows: If True, subtract the per-column mean (the average over the row axis, ``dim=0``)
-            before and after the update, so each column is zero-mean. For MoE routers this respects the
-            logit-shift invariance of the routing softmax.
+            before and after the update, so each column is zero-mean.
         eps: Floor on the Gram eigenvalues for the nuclear-norm computation.
         extra_scale_factor: Extra multiplier on the update.
 
@@ -191,7 +154,7 @@ def one_sided_polargrad_orth_fn(
     gram = m @ m.transpose(-1, -2) if side == "left" else m.transpose(-1, -2) @ m
     eigvals, eigvecs = eigh_with_fallback(gram)
     eigvals.clamp_min_(eps)
-    cutoff = eigvals.amax() * gram.shape[-1] * torch.finfo(torch.float32).eps
+    cutoff = eigvals.amax() * gram.shape[-1] * torch.finfo(m.dtype).eps
     inv_sqrt_eigvals = torch.where(eigvals > cutoff, eigvals.rsqrt(), torch.zeros_like(eigvals))
     gram_inv_sqrt = (eigvecs * inv_sqrt_eigvals.unsqueeze(-2)) @ eigvecs.transpose(-1, -2)
 

--- a/emerging_optimizers/orthogonalized_optimizers/polargrad.py
+++ b/emerging_optimizers/orthogonalized_optimizers/polargrad.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Literal
+
 import torch
 from absl import logging
 from torch.optim.optimizer import ParamsT
@@ -26,7 +28,7 @@ from emerging_optimizers.utils import FP32MatmulPrecT
 from emerging_optimizers.utils.eig import eigh_with_fallback
 
 
-__all__ = ["PolarGrad", "left_polargrad_orth_fn", "right_polargrad_orth_fn"]
+__all__ = ["PolarGrad", "left_polargrad_orth_fn", "one_sided_polargrad_orth_fn", "right_polargrad_orth_fn"]
 
 
 @registry.register_optimizer("polargrad")
@@ -106,93 +108,26 @@ class PolarGrad(OrthogonalizedOptimizer):
 PolarGrad.__doc__ = PolarGrad.__doc__.format(_args_doc=_args_doc)  # type: ignore[union-attr]
 
 
-def right_polargrad_orth_fn(
+def one_sided_polargrad_orth_fn(
     grad: torch.Tensor,
     *,
+    side: Literal["left", "right"],
     alpha: float = 1.0,
     center_rows: bool = False,
     eps: float = 1e-15,
     extra_scale_factor: float = 1.0,
 ) -> torch.Tensor:
-    r"""Right-spectral (one-sided polar) orthogonalization for tall matrices.
+    r"""One-sided (spectral) polar orthogonalization of a matrix.
 
-    Orthogonalizes only the right factor of a tall matrix ``G`` (e.g. an embedding or LM-head weight,
-    ``vocab x hidden``):
-
-    .. math::
-        u = G \, (G^\top G)^{-1/2}, \qquad \text{update} = \lVert G \rVert_*^{\,\alpha} \, u
-
-    .. code-block:: python
-       :caption: Define a ``RightPolarGrad`` by partially applying this orthogonalization
-
-       class RightPolarGrad(OrthogonalizedOptimizer):
-           def __init__(
-               self,
-               params,
-               lr: float = 3e-4,
-               momentum: float = 0.95,
-               weight_decay: float = 0.01,
-               *,
-               ...
-               alpha: float = 1.0,
-               center_rows: bool = False,
-               eps: float = 1e-15,
-               extra_scale_factor: float = 1.0,
-           ) -> None:
-               scaled_orthogonalize_fn = functools.partial(
-                   right_polargrad_orth_fn,
-                   alpha=alpha,
-                   center_rows=center_rows,
-                   eps=eps,
-                   extra_scale_factor=extra_scale_factor,
-               )
-               super().__init__(
-                   ...
-               )
-
-    Args:
-        grad: The (momentum) tensor to orthogonalize.
-        alpha: Exponent applied to the nuclear-norm scale factor.
-        center_rows: If True, subtract the per-column mean (the average over the row / vocabulary axis,
-            ``dim=0``) before and after the update, so each column is zero-mean.
-        eps: Floor on the right-Gram eigenvalues for the inverse sqrt and nuclear-norm computation.
-        extra_scale_factor: Extra multiplier on the update.
-
-    Returns:
-        The scaled right-polar update, same shape and dtype as ``grad``.
-    """
-    m = grad.to(torch.float32)
-    if center_rows:
-        m = m - m.mean(dim=0, keepdim=True)
-
-    eigvals, eigvecs = eigh_with_fallback(m.transpose(-1, -2) @ m)
-    eigvals.clamp_min_(eps)
-    right_gram_inv_sqrt = (eigvecs * eigvals.rsqrt().unsqueeze(-2)) @ eigvecs.transpose(-1, -2)
-
-    u = m @ right_gram_inv_sqrt
-    nuclear_norm = eigvals.sqrt().sum()
-    update = u * nuclear_norm.pow(alpha) * extra_scale_factor
-
-    if center_rows:
-        update = update - update.mean(dim=0, keepdim=True)
-    return update.to(grad.dtype)
-
-
-def left_polargrad_orth_fn(
-    grad: torch.Tensor,
-    *,
-    alpha: float = 1.0,
-    center_rows: bool = False,
-    eps: float = 1e-15,
-    extra_scale_factor: float = 1.0,
-) -> torch.Tensor:
-    r"""Left-spectral (one-sided polar) orthogonalization for wide matrices.
-
-    Orthogonalizes only the left factor of a wide matrix ``G`` (e.g. an MoE router weight,
-    ``num_experts x hidden``):
+    Orthogonalizes a single polar factor of ``G``, selected by ``side``:
 
     .. math::
-        u = (G \, G^\top)^{-1/2} \, G, \qquad \text{update} = \lVert G \rVert_*^{\,\alpha} \, u
+        u_\text{left} = (G \, G^\top)^{-1/2} \, G, \qquad
+        u_\text{right} = G \, (G^\top G)^{-1/2}, \qquad
+        \text{update} = \lVert G \rVert_*^{\,\alpha} \, u
+
+    ``side="right"`` suits tall matrices (e.g. an embedding or LM-head weight, ``vocab x hidden``);
+    ``side="left"`` suits wide matrices (e.g. an MoE router weight, ``num_experts x hidden``).
 
     .. code-block:: python
        :caption: Define a ``LeftPolarGrad`` by partially applying this orthogonalization
@@ -212,7 +147,8 @@ def left_polargrad_orth_fn(
                extra_scale_factor: float = 1.0,
            ) -> None:
                scaled_orthogonalize_fn = functools.partial(
-                   left_polargrad_orth_fn,
+                   one_sided_polargrad_orth_fn,
+                   side="left",
                    alpha=alpha,
                    center_rows=center_rows,
                    eps=eps,
@@ -223,38 +159,80 @@ def left_polargrad_orth_fn(
                )
 
     Note:
-        The inverse square root is computed as a pseudo-inverse: eigendirections of the left Gram that
+        The inverse square root is computed as a pseudo-inverse: eigendirections of the Gram matrix that
         are numerically indistinguishable from its null space contribute nothing to the update instead
-        of being amplified by the ``eps`` floor. This matters because the left Gram is singular whenever
-        ``center_rows=True`` (centering annihilates the all-ones direction) or the matrix has more rows
-        than columns.
+        of being amplified by the ``eps`` floor. This matters because the Gram is singular whenever
+        ``center_rows=True`` on the ``side="left"`` Gram (centering annihilates the all-ones direction)
+        or the matrix is rank deficient.
 
     Args:
         grad: The (momentum) tensor to orthogonalize.
+        side: Which polar factor to orthogonalize, ``"left"`` or ``"right"``.
         alpha: Exponent applied to the nuclear-norm scale factor.
-        center_rows: If True, subtract the per-column mean (the average over the row / expert axis,
-            ``dim=0``) before and after the update, so each column is zero-mean. For MoE routers this
-            respects the logit-shift invariance of the routing softmax.
-        eps: Floor on the left-Gram eigenvalues for the nuclear-norm computation.
+        center_rows: If True, subtract the per-column mean (the average over the row axis, ``dim=0``)
+            before and after the update, so each column is zero-mean. For MoE routers this respects the
+            logit-shift invariance of the routing softmax.
+        eps: Floor on the Gram eigenvalues for the nuclear-norm computation.
         extra_scale_factor: Extra multiplier on the update.
 
     Returns:
-        The scaled left-polar update, same shape and dtype as ``grad``.
+        The scaled one-sided polar update, same shape and dtype as ``grad``.
+
+    Raises:
+        ValueError: If ``side`` is not ``"left"`` or ``"right"``.
     """
+    if side not in ("left", "right"):
+        raise ValueError(f"side must be 'left' or 'right', got {side!r}")
+
     m = grad.to(torch.float32)
     if center_rows:
         m = m - m.mean(dim=0, keepdim=True)
 
-    eigvals, eigvecs = eigh_with_fallback(m @ m.transpose(-1, -2))
+    gram = m @ m.transpose(-1, -2) if side == "left" else m.transpose(-1, -2) @ m
+    eigvals, eigvecs = eigh_with_fallback(gram)
     eigvals.clamp_min_(eps)
-    cutoff = eigvals.amax() * m.shape[-2] * torch.finfo(torch.float32).eps
+    cutoff = eigvals.amax() * gram.shape[-1] * torch.finfo(torch.float32).eps
     inv_sqrt_eigvals = torch.where(eigvals > cutoff, eigvals.rsqrt(), torch.zeros_like(eigvals))
-    left_gram_inv_sqrt = (eigvecs * inv_sqrt_eigvals.unsqueeze(-2)) @ eigvecs.transpose(-1, -2)
+    gram_inv_sqrt = (eigvecs * inv_sqrt_eigvals.unsqueeze(-2)) @ eigvecs.transpose(-1, -2)
 
-    u = left_gram_inv_sqrt @ m
+    u = gram_inv_sqrt @ m if side == "left" else m @ gram_inv_sqrt
     nuclear_norm = eigvals.sqrt().sum()
     update = u * nuclear_norm.pow(alpha) * extra_scale_factor
 
     if center_rows:
         update = update - update.mean(dim=0, keepdim=True)
     return update.to(grad.dtype)
+
+
+def right_polargrad_orth_fn(
+    grad: torch.Tensor,
+    *,
+    alpha: float = 1.0,
+    center_rows: bool = False,
+    eps: float = 1e-15,
+    extra_scale_factor: float = 1.0,
+) -> torch.Tensor:
+    r"""Right-spectral orthogonalization for tall matrices (e.g. embedding or LM-head weights).
+
+    Equivalent to :func:`one_sided_polargrad_orth_fn` with ``side="right"``.
+    """
+    return one_sided_polargrad_orth_fn(
+        grad, side="right", alpha=alpha, center_rows=center_rows, eps=eps, extra_scale_factor=extra_scale_factor
+    )
+
+
+def left_polargrad_orth_fn(
+    grad: torch.Tensor,
+    *,
+    alpha: float = 1.0,
+    center_rows: bool = False,
+    eps: float = 1e-15,
+    extra_scale_factor: float = 1.0,
+) -> torch.Tensor:
+    r"""Left-spectral orthogonalization for wide matrices (e.g. MoE router weights).
+
+    Equivalent to :func:`one_sided_polargrad_orth_fn` with ``side="left"``.
+    """
+    return one_sided_polargrad_orth_fn(
+        grad, side="left", alpha=alpha, center_rows=center_rows, eps=eps, extra_scale_factor=extra_scale_factor
+    )

--- a/tests/test_polargrad.py
+++ b/tests/test_polargrad.py
@@ -196,5 +196,42 @@ class LeftPolarGradOrthFnTest(parameterized.TestCase):
         self.assertTrue(torch.isfinite(param).all())
 
 
+class OneSidedPolarGradOrthFnTest(parameterized.TestCase):
+    def setUp(self):
+        self.device = FLAGS.device
+
+    def test_invalid_side_raises_value_error(self) -> None:
+        grad = torch.randn((4, 8), device=self.device)
+        with self.assertRaisesRegex(ValueError, "side must be 'left' or 'right'"):
+            polargrad.one_sided_polargrad_orth_fn(grad, side="both")
+
+    @parameterized.parameters(("left",), ("right",))
+    def test_wrapper_output_matches_one_sided(self, side) -> None:
+        """left/right wrappers produce bitwise-identical results to side= selection."""
+        grad = torch.randn((8, 32) if side == "left" else (32, 8), device=self.device)
+        wrapper = polargrad.left_polargrad_orth_fn if side == "left" else polargrad.right_polargrad_orth_fn
+
+        assert_equal(
+            wrapper(grad, alpha=1.0, center_rows=True, extra_scale_factor=0.2),
+            polargrad.one_sided_polargrad_orth_fn(
+                grad, side=side, alpha=1.0, center_rows=True, extra_scale_factor=0.2
+            ),
+        )
+
+    @parameterized.parameters((8, 32), (4, 8))
+    def test_left_close_to_transposed_right(self, num_rows, num_cols) -> None:
+        """f_left(G) == f_right(G^T)^T for the shared one-sided polar map."""
+        grad = torch.randn((num_rows, num_cols), device=self.device)
+
+        left = polargrad.one_sided_polargrad_orth_fn(grad, side="left")
+        right_t = polargrad.one_sided_polargrad_orth_fn(grad.transpose(-1, -2), side="right").transpose(-1, -2)
+        torch.testing.assert_close(
+            left,
+            right_t,
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
## What does this PR do?

Follow-up to the #247 review suggestion to consolidate left/right into the same function. Adds `one_sided_polargrad_orth_fn(grad, side="left"|"right")` holding the shared Gram/eigh/pseudo-inverse implementation, and reduces `left_polargrad_orth_fn` / `right_polargrad_orth_fn` to thin wrappers so existing callers and docs entries are unchanged. Invalid `side` raises `ValueError`. Happy to drop the wrappers instead if preferred.

## Behavior note

The shared path uses the pseudo-inverse cutoff introduced in #247 for the left side. On tall full-rank inputs the right side is bit-identical to the previous formula (verified over 800 randomized cases). On rank-deficient inputs (wide matrices, or centered square ones) the previous right formula amplified eigh noise through `clamp_min(1e-15).rsqrt()`, producing updates up to ~3e4 in magnitude; the shared path drops those null directions and stays at the nuclear-norm scale.

## Tests

- `test_invalid_side_raises_value_error`
- `test_wrapper_output_matches_one_sided` (bitwise, both sides)
- `test_left_close_to_transposed_right` (mirror identity `f_left(G) == f_right(G^T)^T`)
- Existing left/right test classes are unchanged and now exercise the wrappers end-to-end.

Verified locally: `test_polargrad.py` (34 tests) and `test_orthogonalized_optimizer.py` (143 tests) pass on `--device=cpu` and `--device=cuda`, random seed and `--seed=42`; pre-commit (ruff, mypy, format) clean.
