### PR TITLE
MOSO: default inner-Adam beta1 to 0.0 to avoid double momentum

### DIFF
--- a/emerging_optimizers/soap/moso.py
+++ b/emerging_optimizers/soap/moso.py
@@ -67,7 +67,7 @@ class MOSO(opt_mixin.WeightDecayMixin, optim.Optimizer):
         params: ParamsT,
         lr: float = 3e-4,
         momentum: float = 0.95,
-        betas: tuple[float, float] = (0.9, 0.95),
+        betas: tuple[float, float] = (0.0, 0.95),
         shampoo_beta: float = 0.95,
         eps: float = 1e-8,
         weight_decay: float = 0.01,


### PR DESCRIPTION
Summary

By default, MOSO applies two first-moment EMAs to the update direction:

1. the Muon-style momentum buffer (momentum=0.95), applied to the gradient before preconditioning, and
2. the inner Adam first moment (betas[0]=0.9), applied to the projected momentum inside the eigenbasis.

Since the momentum buffer already smooths the gradient, the inner Adam's beta1 averages the update direction a second time. This over-damping measurably slows convergence.

This PR defaults betas to (0.0, 0.95), so momentum is applied once (via the Muon buffer) and the inner Adam contributes only second-moment (RMS) normalization in the eigenbasis — consistent with the class's stated design ("tracks EMA momentum like Muon"). The previous behavior remains one kwarg away: betas=(0.9, 0.95).