### PR TITLE
MOSO: use RMSProp directly (remove double momentum)

### DIFF
--- a/emerging_optimizers/scalar_optimizers/update_functions/__init__.py
+++ b/emerging_optimizers/scalar_optimizers/update_functions/__init__.py
@@ -17,6 +17,7 @@ from emerging_optimizers.scalar_optimizers.update_functions.ademamix import *
 from emerging_optimizers.scalar_optimizers.update_functions.laprop import *
 from emerging_optimizers.scalar_optimizers.update_functions.lion import *
 from emerging_optimizers.scalar_optimizers.update_functions.madam import *
+from emerging_optimizers.scalar_optimizers.update_functions.rmsprop import *
 from emerging_optimizers.scalar_optimizers.update_functions.signum import *
 
 
@@ -26,6 +27,7 @@ __all__ = [
     "calculate_laprop_update",
     "calculate_lion_update",
     "calculate_madam_update",
+    "calculate_rmsprop_update",
     "calculate_signum_update",
     "calculate_sim_ademamix_update",
 ]

--- a/emerging_optimizers/scalar_optimizers/update_functions/rmsprop.py
+++ b/emerging_optimizers/scalar_optimizers/update_functions/rmsprop.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import torch
+
+
+__all__ = [
+    "calculate_rmsprop_update",
+]
+
+
+@torch.compile  # type: ignore[misc]
+@torch.no_grad()  # type: ignore[misc]
+def calculate_rmsprop_update(
+    grad: torch.Tensor,
+    exp_avg_sq: torch.Tensor,
+    *,
+    alpha: float,
+    eps: float,
+) -> torch.Tensor:
+    """Performs the RMSProp update.
+
+    This function performs the computation of 1 step of RMSProp, matching
+    ``torch.optim.RMSprop`` with ``momentum=0`` and ``centered=False``.
+
+    The update rule is as follows:
+
+    .. math::
+        v_t = \\alpha v_{t-1} + (1 - \\alpha) g_t^2 \\\\
+        \\text{update} = \\frac{g_t}{\\sqrt{v_t} + \\epsilon} \\\\
+
+    Args:
+        grad: The gradient tensor.
+        exp_avg_sq: The accumulated second moment of the gradient (modified in place).
+        alpha: The EMA coefficient for the second moment.
+        eps: Epsilon for the second-moment denominator.
+
+    Returns:
+        The RMSProp update.
+    """
+    exp_avg_sq.lerp_(grad.square(), 1 - alpha)
+    return grad / (exp_avg_sq.sqrt() + eps)

--- a/emerging_optimizers/soap/moso.py
+++ b/emerging_optimizers/soap/moso.py
@@ -37,19 +37,19 @@ class MOSO(opt_mixin.WeightDecayMixin, optim.Optimizer):
     r"""Momentum One-Sided SOAP.
 
     MOSO tracks EMA momentum like Muon, accumulates a SOAP/Shampoo-style covariance of that momentum on the
-    smaller matrix side, and applies an Adam update in the covariance eigenbasis.
+    smaller matrix side, and applies an RMSProp update in the covariance eigenbasis.
     Conceptually, this is one-sided SOAP where ``G_t G_t^T`` is replaced by ``M_t M_t^T`` (or ``M_t^T M_t`` for the
-    right side), and the update is computed by projecting the momentum into the eigenbasis, applying Adam there, and
-    projecting back:
+    right side), and the update is computed by projecting the momentum into the eigenbasis, applying RMSProp there,
+    and projecting back:
 
     .. math::
 
         C_t = \beta_s C_{t-1} + (1 - \beta_s) M_t M_t^T,\quad C_t = Q_M \Lambda_M Q_M^T
 
-        U_t = Q_M \operatorname{Adam}(Q_M^T M_t)
+        U_t = Q_M \operatorname{RMSprop}(Q_M^T M_t)
 
     for the left-preconditioned case where ``M_t.shape[0] <= M_t.shape[1]``; the right-preconditioned case uses
-    ``C_t = M_t^T M_t`` and computes ``U_t = \operatorname{Adam}(M_t Q_M) Q_M^T``.
+    ``C_t = M_t^T M_t`` and computes ``U_t = \operatorname{RMSprop}(M_t Q_M) Q_M^T``.
 
     Args:
         params: Iterable of parameters to optimize or dicts defining parameter groups.
@@ -57,7 +57,7 @@ class MOSO(opt_mixin.WeightDecayMixin, optim.Optimizer):
         momentum: EMA coefficient for the Muon-style momentum.
         rms_beta: EMA coefficient for the second-moment (RMS) normalization in the eigenbasis.
         shampoo_beta: EMA coefficient for the one-sided momentum covariance.
-        eps: Inner Adam epsilon for numerical stability.
+        eps: RMSProp epsilon for numerical stability.
         weight_decay: Weight decay coefficient.
         max_update_rms: Clip the update RMS to this value (0 means no clipping).
     """
@@ -107,7 +107,6 @@ class MOSO(opt_mixin.WeightDecayMixin, optim.Optimizer):
                 preconditioner_size = min(rows, cols)
                 state["step"] = 0
                 state["momentum_buffer"] = torch.zeros_like(p.data, dtype=torch.float32)
-                state["exp_avg"] = torch.zeros_like(p.data, dtype=torch.float32)
                 state["exp_avg_sq"] = torch.zeros_like(p.data, dtype=torch.float32)
                 state["M"] = torch.zeros(
                     preconditioner_size,
@@ -164,10 +163,9 @@ class MOSO(opt_mixin.WeightDecayMixin, optim.Optimizer):
 
                 left_preconditioned = momentum.shape[0] <= momentum.shape[1]
                 with utils.fp32_matmul_precision("highest"):
-                    state["Q_M"], state["exp_avg"], state["exp_avg_sq"] = _update_eigenbasis_and_adam_exp_avgs(
+                    state["Q_M"], state["exp_avg_sq"] = _update_eigenbasis_and_exp_avg_sq(
                         momentum_factor=state["M"],
                         eigenbasis=state["Q_M"],
-                        exp_avg=state["exp_avg"],
                         exp_avg_sq=state["exp_avg_sq"],
                         left_preconditioned=left_preconditioned,
                         use_eigh=state["step"] == 0,
@@ -180,18 +178,14 @@ class MOSO(opt_mixin.WeightDecayMixin, optim.Optimizer):
                         eigenbasis=state["Q_M"],
                         left_preconditioned=left_preconditioned,
                     )
-                    adam_update = update_functions.calculate_adam_update(
+                    rmsprop_update = update_functions.calculate_rmsprop_update(
                         momentum_projected,
-                        state["exp_avg"],
                         state["exp_avg_sq"],
-                        betas=(0.0, group["rms_beta"]),
+                        alpha=group["rms_beta"],
                         eps=group["eps"],
-                        correct_bias=True,
-                        nesterov=False,
-                        step=curr_iter_1_based,
                     )
                     update = _project_from_one_sided_eigenbasis(
-                        x=adam_update,
+                        x=rmsprop_update,
                         eigenbasis=state["Q_M"],
                         left_preconditioned=left_preconditioned,
                     )
@@ -217,23 +211,16 @@ def _update_one_sided_momentum_factor(
 
 
 @torch.no_grad()  # type: ignore[misc]
-def _update_eigenbasis_and_adam_exp_avgs(
+def _update_eigenbasis_and_exp_avg_sq(
     momentum_factor: torch.Tensor,
     eigenbasis: torch.Tensor,
-    exp_avg: torch.Tensor,
     exp_avg_sq: torch.Tensor,
     left_preconditioned: bool,
     *,
     use_eigh: bool,
     power_iter_steps: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Update one eigenbasis and keep Adam state aligned with that basis."""
-    exp_avg = _project_from_one_sided_eigenbasis(
-        x=exp_avg,
-        eigenbasis=eigenbasis,
-        left_preconditioned=left_preconditioned,
-    )
-
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Update one eigenbasis and keep the RMSProp second moment aligned with that basis."""
     if use_eigh:
         _, (updated_eigenbasis,) = soap_utils.get_eigenbasis_eigh([momentum_factor])
     else:
@@ -250,12 +237,7 @@ def _update_eigenbasis_and_adam_exp_avgs(
             power_iter_steps=power_iter_steps,
         )
 
-    exp_avg = _project_to_one_sided_eigenbasis(
-        x=exp_avg,
-        eigenbasis=updated_eigenbasis,
-        left_preconditioned=left_preconditioned,
-    )
-    return updated_eigenbasis, exp_avg, exp_avg_sq
+    return updated_eigenbasis, exp_avg_sq
 
 
 @torch.no_grad()  # type: ignore[misc]

--- a/emerging_optimizers/soap/moso.py
+++ b/emerging_optimizers/soap/moso.py
@@ -55,7 +55,7 @@ class MOSO(opt_mixin.WeightDecayMixin, optim.Optimizer):
         params: Iterable of parameters to optimize or dicts defining parameter groups.
         lr: Learning rate.
         momentum: EMA coefficient for the Muon-style momentum.
-        betas: Inner Adam beta parameters ``(beta1, beta2)``.
+        rms_beta: EMA coefficient for the second-moment (RMS) normalization in the eigenbasis.
         shampoo_beta: EMA coefficient for the one-sided momentum covariance.
         eps: Inner Adam epsilon for numerical stability.
         weight_decay: Weight decay coefficient.
@@ -67,7 +67,7 @@ class MOSO(opt_mixin.WeightDecayMixin, optim.Optimizer):
         params: ParamsT,
         lr: float = 3e-4,
         momentum: float = 0.95,
-        betas: tuple[float, float] = (0.9, 0.95),
+        rms_beta: float = 0.95,
         shampoo_beta: float = 0.95,
         eps: float = 1e-8,
         weight_decay: float = 0.01,
@@ -80,7 +80,7 @@ class MOSO(opt_mixin.WeightDecayMixin, optim.Optimizer):
         defaults = {
             "lr": lr,
             "momentum": momentum,
-            "betas": betas,
+            "rms_beta": rms_beta,
             "shampoo_beta": shampoo_beta,
             "eps": eps,
             "weight_decay": weight_decay,
@@ -184,7 +184,7 @@ class MOSO(opt_mixin.WeightDecayMixin, optim.Optimizer):
                         momentum_projected,
                         state["exp_avg"],
                         state["exp_avg_sq"],
-                        betas=group["betas"],
+                        betas=(0.0, group["rms_beta"]),
                         eps=group["eps"],
                         correct_bias=True,
                         nesterov=False,

--- a/tests/test_moso.py
+++ b/tests/test_moso.py
@@ -137,9 +137,8 @@ class MOSOTest(parameterized.TestCase):
         with self.assertRaisesRegex(TypeError, "only supported for 2D"):
             optimizer.step()
 
-    def test_no_inner_first_moment_momentum(self) -> None:
+    def test_betas_raise_type_error(self) -> None:
         param = torch.randn((4, 4), requires_grad=True, device=FLAGS.device)
-        MOSO([param], lr=0.001, rms_beta=0.9)
         with self.assertRaises(TypeError):
             MOSO([param], lr=0.001, betas=(0.9, 0.95))
 

--- a/tests/test_moso.py
+++ b/tests/test_moso.py
@@ -101,7 +101,7 @@ class MOSOTest(parameterized.TestCase):
             [param],
             lr=lr,
             momentum=0.0,
-            betas=(0.0, 0.0),
+            rms_beta=0.0,
             shampoo_beta=0.0,
             eps=1e-12,
             weight_decay=0.0,
@@ -136,6 +136,12 @@ class MOSOTest(parameterized.TestCase):
 
         with self.assertRaisesRegex(TypeError, "only supported for 2D"):
             optimizer.step()
+
+    def test_no_inner_first_moment_momentum(self) -> None:
+        param = torch.randn((4, 4), requires_grad=True, device=FLAGS.device)
+        MOSO([param], lr=0.001, rms_beta=0.9)
+        with self.assertRaises(TypeError):
+            MOSO([param], lr=0.001, betas=(0.9, 0.95))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
MOSO applies a Muon-style first-moment EMA (`momentum`) to the gradient **before** preconditioning. The inner Adam previously **also** exposed `beta1`, adding a second, redundant momentum on the projected update direction. This double-averaging over-damps the update and measurably hurts convergence — and it was reachable by default (`betas=(0.9, 0.95)`).

This PR removes the inner first moment entirely and makes double momentum **structurally impossible**: the inner optimizer is now **RMSProp** (`calculate_rmsprop_update`, matching `torch.optim.RMSprop` with `momentum=0, centered=False`), controlled by a single `rms_beta`. The now-dead `exp_avg` first-moment state and its eigenbasis reprojection are removed. There is no longer any API surface to add a second momentum.

```diff
-        betas: tuple[float, float] = (0.9, 0.95),
+        rms_beta: float = 0.95,
-        adam_update = update_functions.calculate_adam_update(..., betas=(0.0, rms_beta), correct_bias=True, ...)
+        rmsprop_update = update_functions.calculate_rmsprop_update(..., alpha=rms_beta, eps=...)
```

## Evidence
Hybrid Mamba + 128-expert MoE, WSD schedule, per-config LR-tuned. Removing the inner first moment (`beta1 0.9 → 0`):

| rung | old default (`beta1=0.9`) | fixed (no inner momentum) | Δ |
|------|---------------------------|---------------------------|-----|
| 1B (88B tok) | 1.7238 | **1.6268** | −0.097 |

- Holds across a **1B → 7B scaling ladder**: the fixed optimizer beats the AdamW baseline at every scale (1B 1.627, 2B 1.512, 4B 1.433, 7B 1.359) and closes most of the gap to Muon+Lion / SOAP-KL; the old default was the *worst* of the four optimizers.
- The **RMSProp** form (this PR) was re-validated at 1B against the `beta1=0` Adam form: the two are identical after the first ~200 steps — RMSProp drops the second-moment bias correction, which only affects the earliest steps (a benign larger-step transient).

## Behavior / compatibility
- **Breaking API change:** `betas` is removed; use `rms_beta`. The old `(0.9, 0.95)` behavior is intentionally no longer reachable.
- The inner update is RMSProp rather than Adam-with-`beta1=0`; numerically identical after the bias-correction warmup.