### PR TITLE
fix: in-place torch.addmm with beta=0 uses same input/output tensor

### DIFF
--- a/emerging_optimizers/riemannian_optimizers/isospectral.py
+++ b/emerging_optimizers/riemannian_optimizers/isospectral.py
@@ -225,9 +225,9 @@ class Iso(Optimizer):
                     )
                     scaled_u = u * sigma.unsqueeze(0)
                     if param.dtype == torch.float32:
-                        torch.addmm(param, scaled_u, v.mT, beta=0.0, out=param)
+                        torch.mm(scaled_u, v.mT, out=param)
                     else:
-                        # Mixed-dtype addmm cannot write an FP32 result directly into param.
+                        # Mixed-dtype mm cannot write an FP32 result directly into param.
                         param.copy_(torch.mm(scaled_u, v.mT))
 
                 state["u"] = u

--- a/tests/test_isospectral.py
+++ b/tests/test_isospectral.py
@@ -70,6 +70,18 @@ class IsospectralTest(parameterized.TestCase):
         assert_close_to_orthogonal(state["u"], diag_atol=1e-5, off_diag_atol=1e-5)
         assert_close_to_orthogonal(state["v"], diag_atol=1e-5, off_diag_atol=1e-5)
 
+    def test_fp32_parameter_reconstructed_in_place(self) -> None:
+        param = torch.nn.Parameter(torch.randn((6, 4), device=FLAGS.device))
+        initial_param = param.detach().clone()
+        optimizer = Iso([param], lr=1e-2)
+        param.grad = torch.randn_like(param)
+
+        optimizer.step()
+
+        self.assertEqual(param.dtype, torch.float32)
+        self.assertTrue(torch.isfinite(param).all())
+        self.assertFalse(torch.equal(param, initial_param))
+
     @parameterized.named_parameters(
         ("float16", torch.float16),
         ("bfloat16", torch.bfloat16),


### PR DESCRIPTION
This PR addresses the following issue in `emerging_optimizers/riemannian_optimizers/isospectral.py`: in-place torch.addmm with beta=0 uses same input/output tensor.

## Changes
- `emerging_optimizers/riemannian_optimizers/isospectral.py`: in-place torch.addmm with beta=0 uses same input/output tensor.

## Details
```diff
--- a/emerging_optimizers/riemannian_optimizers/isospectral.py
+++ b/emerging_optimizers/riemannian_optimizers/isospectral.py
@@ -1,6 +1,6 @@
-                    scaled_u = u * sigma.unsqueeze(0)
-                    if param.dtype == torch.float32:
-                        torch.addmm(param, scaled_u, v.mT, beta=0.0, out=param)
-                    else:
-                        # Mixed-dtype addmm cannot write an FP32 result directly into param.
-                        param.copy_(torch.mm(scaled_u, v.mT))
+                    scaled_u = u * sigma.unsqueeze(0)
+                    if param.dtype == torch.float32:
+                        torch.mm(scaled_u, v.mT, out=param)
+                    else:
+                        # Mixed-dtype mm cannot write an FP32 result directly into param.
+                        param.copy_(torch.mm(scaled_u, v.mT))
```

## Tests
- `tests/test_isospectral.py`

```diff
--- a/tests/test_isospectral.py
+++ b/tests/test_isospectral.py
@@ -1,11 +1,23 @@
-    def test_factor_state_is_orthonormal(self) -> None:
-        param = torch.nn.Parameter(torch.randn((7, 4), device=FLAGS.device))
-        optimizer = Iso([param], lr=1e-2)
-        param.grad = torch.randn_like(param)
-        optimizer.step()
-
-        state = optimizer.state[param]
-        assert_close_to_orthogonal(state["u"], diag_atol=1e-5, off_diag_atol=1e-5)
-        assert_close_to_orthogonal(state["v"], diag_atol=1e-5, off_diag_atol=1e-5)
-
-    @parameterized.named_parameters(
+    def test_factor_state_is_orthonormal(self) -> None:
+        param = torch.nn.Parameter(torch.randn((7, 4), device=FLAGS.device))
+        optimizer = Iso([param], lr=1e-2)
+        param.grad = torch.randn_like(param)
+        optimizer.step()
+
+        state = optimizer.state[param]
+        assert_close_to_orthogonal(state["u"], diag_atol=1e-5, off_diag_atol=1e-5)
+        assert_close_to_orthogonal(state["v"], diag_atol=1e-5, off_diag_atol=1e-5)
+
+    def test_fp32_parameter_reconstructed_in_place(self) -> None:
+        param = torch.nn.Parameter(torch.randn((6, 4), device=FLAGS.device))
+        initial_param = param.detach().clone()
+        optimizer = Iso([param], lr=1e-2)
+        param.grad = torch.randn_like(param)
+
+        optimizer.step()
+
+        self.assertEqual(param.dtype, torch.float32)
+        self.assertTrue(torch.isfinite(param).all())
+        self.assertFalse(torch.equal(param, initial_param))
+
+    @parameterized.named_parameters(
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).