### PR TITLE
fix: validate 2D parameters in Iso constructor instead of step

### DIFF
--- a/emerging_optimizers/riemannian_optimizers/isospectral.py
+++ b/emerging_optimizers/riemannian_optimizers/isospectral.py
@@ -149,6 +149,11 @@ class Iso(Optimizer):
         self.fp32_matmul_prec = fp32_matmul_prec
         super().__init__(params, defaults)
 
+        for group in self.param_groups:
+            for param in group["params"]:
+                if param.ndim != 2:
+                    raise ValueError("Iso only supports 2D parameters")
+
     @torch.no_grad()  # type: ignore[misc]
     def _init_state(self, param: torch.Tensor) -> None:
         state = self.state[param]
@@ -193,8 +198,6 @@ class Iso(Optimizer):
             for param in group["params"]:
                 if param.grad is None:
                     continue
-                if param.ndim != 2:
-                    raise ValueError("Iso only supports 2D parameters")
                 if param.grad.is_sparse:
                     raise ValueError("Iso does not support sparse gradients")
 

--- a/tests/test_isospectral.py
+++ b/tests/test_isospectral.py
@@ -92,11 +92,8 @@ class IsospectralTest(parameterized.TestCase):
 
     def test_rejects_non_matrix_parameter(self) -> None:
         param = torch.nn.Parameter(torch.randn(4, device=FLAGS.device))
-        optimizer = Iso([param])
-        param.grad = torch.randn_like(param)
-
         with self.assertRaisesRegex(ValueError, "only supports 2D"):
-            optimizer.step()
+            Iso([param])
 
     @parameterized.named_parameters(
         ("negative_lr", {"lr": -1e-3}, "learning rate"),


### PR DESCRIPTION
This PR addresses the following issue in `emerging_optimizers/riemannian_optimizers/isospectral.py`: validate 2D parameters in Iso constructor instead of step.

## Changes
- `emerging_optimizers/riemannian_optimizers/isospectral.py`: validate 2D parameters in Iso constructor instead of step.

## Details
```diff
--- a/emerging_optimizers/riemannian_optimizers/isospectral.py
+++ b/emerging_optimizers/riemannian_optimizers/isospectral.py
@@ -130,7 +130,13 @@ class Iso(Optimizer):
         defaults = {
             "lr": lr,
             "momentum": momentum,
             "retraction": retraction,
         }
         self.fp32_matmul_prec = fp32_matmul_prec
         super().__init__(params, defaults)
+
+        for group in self.param_groups:
+            for param in group["params"]:
+                if param.ndim != 2:
+                    raise ValueError("Iso only supports 2D parameters")
 
     @torch.no_grad()  # type: ignore[misc]
@@ -174,12 +180,10 @@ class Iso(Optimizer):
         for group in self.param_groups:
             lr = group["lr"]
             momentum = group["momentum"]
             retraction = group["retraction"]
 
             for param in group["params"]:
                 if param.grad is None:
                     continue
-                if param.ndim != 2:
-                    raise ValueError("Iso only supports 2D parameters")
                 if param.grad.is_sparse:
                     raise ValueError("Iso does not support sparse gradients")
```

## Tests
- `tests/test_isospectral.py`

```diff
--- a/tests/test_isospectral.py
+++ b/tests/test_isospectral.py
@@ -92,7 +92,4 @@ class IsospectralTest(parameterized.TestCase):
     def test_rejects_non_matrix_parameter(self) -> None:
         param = torch.nn.Parameter(torch.randn(4, device=FLAGS.device))
-        optimizer = Iso([param])
-        param.grad = torch.randn_like(param)
-
         with self.assertRaisesRegex(ValueError, "only supports 2D"):
-            optimizer.step()
+            Iso([param])
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).