### PR TITLE
Update eigen bases sorting in SOAP

### DIFF
--- a/emerging_optimizers/soap/moso.py
+++ b/emerging_optimizers/soap/moso.py
@@ -225,11 +225,6 @@ def _update_eigenbasis_and_exp_avg_sq(
         _, (updated_eigenbasis,) = soap_utils.get_eigenbasis_eigh([momentum_factor])
     else:
         x = exp_avg_sq if left_preconditioned else exp_avg_sq.mT
-        (eigenbasis,), x = soap_utils.permute_eigenbasis_and_exp_avg_sq(
-            [momentum_factor],
-            [eigenbasis],
-            x,
-        )
         exp_avg_sq = x if left_preconditioned else x.mT
         _, (updated_eigenbasis,) = soap_utils.get_eigenbasis_qr(
             [momentum_factor],

--- a/emerging_optimizers/soap/soap.py
+++ b/emerging_optimizers/soap/soap.py
@@ -446,13 +446,6 @@ def update_eigenbasis_and_exp_avgs(
             kronecker_factor_list,
         )
     else:
-        # Permute the eigenbases (and the matching exp_avg_sq slots) by descending approximate eigenvalues
-        # before power iteration
-        eigenbasis_list, exp_avg_sq = soap_utils.permute_eigenbasis_and_exp_avg_sq(
-            kronecker_factor_list,
-            eigenbasis_list,
-            exp_avg_sq,
-        )
         updated_eigvals_list, updated_eigenbasis_list = soap_utils.get_eigenbasis_qr(
             kronecker_factor_list,
             eigenbasis_list,

--- a/emerging_optimizers/soap/soap_utils.py
+++ b/emerging_optimizers/soap/soap_utils.py
@@ -17,7 +17,6 @@ from typing import TypeAlias
 
 import torch
 
-from emerging_optimizers import utils
 from emerging_optimizers.utils import eig as eig_utils
 
 
@@ -125,18 +124,18 @@ def get_eigenbasis_qr(
             More steps can lead to better convergence but increased computation time.
 
     Returns:
-        Tuple of (list of approximate eigenvalues of each kronecker factor in its updated eigenbasis,
-        updated list of orthonormal eigenbases (QL and QR)).
+        Tuple of (list of approximate eigenvalues in descending order, updated list of orthonormal
+        eigenbases (QL and QR) with columns ordered to match).
     """
     updated_eigenbasis_list: TensorList = []
     updated_eigvals_list: TensorList = []
     for kronecker_factor, eigenbasis in zip(kronecker_factor_list, eigenbasis_list, strict=True):
-        Q = eigenbasis
-        for _ in range(power_iter_steps):
-            Q = kronecker_factor @ Q
-            Q = torch.linalg.qr(Q).Q
-        with utils.fp32_matmul_precision("highest"):
-            updated_eigvals_list.append(eig_utils.conjugate(kronecker_factor, Q, diag=True))
-        updated_eigenbasis_list.append(Q)
+        eigvals, eigenbasis = eig_utils.orthogonal_iteration(
+            kronecker_factor=kronecker_factor,
+            eigenbasis=eigenbasis,
+            power_iter_steps=power_iter_steps,
+        )
+        updated_eigvals_list.append(eigvals)
+        updated_eigenbasis_list.append(eigenbasis)
 
     return updated_eigvals_list, updated_eigenbasis_list

--- a/emerging_optimizers/soap/soap_utils.py
+++ b/emerging_optimizers/soap/soap_utils.py
@@ -27,7 +27,6 @@ __all__ = [
     "get_eigenbasis_eigh",
     "get_eigenbasis_qr",
     "get_eigenbasis_svd",
-    "permute_eigenbasis_and_exp_avg_sq",
 ]
 
 
@@ -77,37 +76,6 @@ def get_eigenbasis_svd(
         updated_eigenbasis_list.append(U)
 
     return updated_eigenbasis_list
-
-
-def permute_eigenbasis_and_exp_avg_sq(
-    kronecker_factor_list: TensorList,
-    eigenbasis_list: TensorList,
-    exp_avg_sq: torch.Tensor,
-) -> tuple[TensorList, torch.Tensor]:
-    """Permute each eigenbasis and the matching ``exp_avg_sq`` axis by descending approximate eigenvalues.
-
-    Computes the approximate eigenvalues of each eigenbasis against its kronecker factor (the Rayleigh
-    quotients :math:`\\mathrm{diag}(Q^{\\top} K Q)`) and permutes the eigenbasis columns into descending
-    order, permuting ``exp_avg_sq`` along the corresponding axis so its per-slot statistics stay
-    aligned. Used before :func:`get_eigenbasis_qr`, whose orthogonal iteration is column-order
-    sensitive; the eigh path does not need it since it rebuilds the eigenbasis from scratch.
-
-    Args:
-        kronecker_factor_list: List of preconditioner matrices (L and R).
-        eigenbasis_list: List of current eigenbases (QL and QR).
-        exp_avg_sq: Inner Adam second moment tensor, permuted along each kronecker-factor axis to
-            match the new descending-eigenvalue column ordering.
-
-    Returns:
-        ``(permuted_eigenbasis_list, permuted_exp_avg_sq)``.
-    """
-    permuted_eigenbasis_list: TensorList = []
-    for ind, (kronecker_factor, eigenbasis) in enumerate(zip(kronecker_factor_list, eigenbasis_list, strict=True)):
-        approx_eigvals = eig_utils.conjugate(kronecker_factor, eigenbasis, diag=True)
-        sort_idx = torch.argsort(approx_eigvals, descending=True)
-        permuted_eigenbasis_list.append(eigenbasis[:, sort_idx])
-        exp_avg_sq = exp_avg_sq.index_select(ind, sort_idx)
-    return permuted_eigenbasis_list, exp_avg_sq
 
 
 def get_eigenbasis_qr(

--- a/tests/soap_reference.py
+++ b/tests/soap_reference.py
@@ -49,6 +49,8 @@ class ReferenceSoap(optim.Optimizer):
 
     Note:
         Order of operations are slightly changed from original code to match our algorithmic choices.
+        * Current step's gradient is included in the Kronecker factors.
+        * QR path sort eigen basis right after power iteration.
     """
 
     def __init__(
@@ -376,16 +378,15 @@ class ReferenceSoap(optim.Optimizer):
             exp_avg_sq = state["exp_avg_sq"]
 
         final = []
-        for ind, (m, o) in enumerate(zip(matrix, orth_matrix)):
+        for m, o in zip(matrix, orth_matrix):
             if len(m) == 0:
                 final.append([])
                 continue
-            est_eig = torch.diag(o.T @ m @ o)
-            sort_idx = torch.argsort(est_eig, descending=True)
-            exp_avg_sq = exp_avg_sq.index_select(ind, sort_idx)
-            o = o[:, sort_idx]
             power_iter = m @ o
             Q, _ = torch.linalg.qr(power_iter)
+            est_eig = (Q.T @ m * Q.T).sum(dim=-1)
+            sort_idx = torch.argsort(est_eig, descending=True)
+            Q = Q[:, sort_idx]
 
             if not float_data:
                 Q = Q.to(original_device).type(original_type)

--- a/tests/test_soap.py
+++ b/tests/test_soap.py
@@ -454,10 +454,10 @@ class SoapVsReferenceTest(parameterized.TestCase):
 
     @parameterized.product(
         shape=[(3, 3), (5, 3), (10, 10), (15, 31)],
-        num_steps=[2, 5, 7],
+        num_steps=[1, 2, 5, 7],
         correct_bias=[False, True],
     )
-    def test_update_matches_reference(self, shape: tuple, num_steps: int, correct_bias: bool):
+    def test_update_close_to_reference(self, shape: tuple, num_steps: int, correct_bias: bool):
         """Test that SOAP optimizer matches reference implementation for basic config."""
         # Create two identical parameters
         param_test = torch.randint(-2, 3, shape, dtype=torch.float32, device=self.device)
@@ -503,8 +503,8 @@ class SoapVsReferenceTest(parameterized.TestCase):
             torch.testing.assert_close(
                 param_test,
                 param_ref,
-                atol=1e-4,
-                rtol=1e-4,
+                atol=1e-5,
+                rtol=1e-5,
                 msg=lambda msg: f"Parameter mismatch at step {step}:\n{msg}",
             )
 
@@ -515,7 +515,7 @@ class SoapVsReferenceTest(parameterized.TestCase):
         shape=[(3, 3), (5, 3), (10, 10), (15, 31)],
         num_steps=[2, 5, 7],
     )
-    def test_eigenbasis_matches_reference(self, shape: tuple, num_steps: int):
+    def test_eigenbasis_close_to_reference(self, shape: tuple, num_steps: int):
         param_soap = torch.randint(-2, 3, shape, dtype=torch.float32, device=self.device)
         param_ref = param_soap.clone()
 

--- a/tests/test_soap_utils.py
+++ b/tests/test_soap_utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import torch
-from _comparison import assert_close_to_identity, assert_equal
+from _comparison import assert_close_to_identity
 from absl import flags, logging
 from absl.testing import absltest, parameterized
 
@@ -89,55 +89,6 @@ class SoapUtilsTest(BaseTestCase):
                 rtol=1e-5,
                 msg=lambda msg: f"eigvals do not match the Rayleigh quotients diag(Q^T K Q)\n\n{msg}",
             )
-
-    @parameterized.parameters(  # type: ignore[misc]
-        {"N": 4, "M": 8},
-        {"N": 16, "M": 8},
-    )
-    def test_permute_eigenbasis_and_exp_avg_sq(self, N: int, M: int) -> None:
-        """Permutes eigenbasis columns and exp_avg_sq slots consistently, in descending eigval order."""
-        g = torch.randint(-5, 6, (M, N), device=self.device) / 16.0
-        # Add a small ridge so K is full-rank (g @ g.t() is rank-deficient when M > N, etc.),
-        # which keeps the approximate eigenvalues away from numerical zero where ordering becomes
-        # ambiguous under float rounding.
-        eps_eye = lambda n: 1e-3 * torch.eye(n, device=self.device)
-        kronecker_factor_list = [g @ g.t() + eps_eye(M), g.t() @ g + eps_eye(N)]
-        eigenbasis_list = [torch.linalg.qr(Q).Q for Q in kronecker_factor_list]
-        exp_avg_sq = torch.abs(torch.randint(-5, 6, (M, N), device=self.device) / 16.0)
-
-        permuted_eigenbasis_list, permuted_exp_avg_sq = soap_utils.permute_eigenbasis_and_exp_avg_sq(
-            kronecker_factor_list,
-            eigenbasis_list,
-            exp_avg_sq,
-        )
-
-        # Compute the expected per-axis permutations from the originals.
-        sort_idx_list = []
-        for K, Q in zip(kronecker_factor_list, eigenbasis_list, strict=True):
-            sort_idx_list.append(torch.argsort(torch.diag(Q.t() @ K @ Q), descending=True))
-
-        # Each eigenbasis is column-permuted by its own sort_idx.
-        for i, (Q_old, Q_permuted) in enumerate(zip(eigenbasis_list, permuted_eigenbasis_list, strict=True)):
-            assert_equal(
-                Q_permuted,
-                Q_old[:, sort_idx_list[i]],
-                msg=lambda m, i=i: f"eigenbasis i={i} not permuted by sort_idx\n\n{m}",
-            )
-
-        # exp_avg_sq is permuted along every axis cumulatively.
-        expected_sq = exp_avg_sq
-        for i, sort_idx in enumerate(sort_idx_list):
-            expected_sq = expected_sq.index_select(i, sort_idx)
-        assert_equal(
-            permuted_exp_avg_sq,
-            expected_sq,
-            msg=lambda m: f"exp_avg_sq not permuted to match permuted eigenbases\n\n{m}",
-        )
-
-        # Permuted eigenbases yield descending approximate eigenvalues.
-        for K, Q in zip(kronecker_factor_list, permuted_eigenbasis_list, strict=True):
-            permuted_eigvals = torch.diag(Q.t() @ K @ Q)
-            self.assertTrue(torch.all(permuted_eigvals[:-1] >= permuted_eigvals[1:]))
 
     @parameterized.parameters(  # type: ignore[misc]
         {"dims": [128, 512]},


### PR DESCRIPTION
Correct a mixed eigen value approximation and avg_exp_sq alignment inherited from original reference.

Eigen values should be approximated by eigen vectors and the original matrix that obtained the eigen vectors, not mixing updated L/R with previous step's eigen bases.