### PR TITLE
Update matrix inverse root via CANS

### DIFF
--- a/emerging_optimizers/soap/matrix_root_inverse_utils.py
+++ b/emerging_optimizers/soap/matrix_root_inverse_utils.py
@@ -80,13 +80,17 @@ def mat_root_inv_via_scaled_cans(
     inf_norm = torch.linalg.matrix_norm(x, ord=float("inf"), dim=(-2, -1), keepdim=True).clamp_min_(eps)
     y = x / inf_norm
 
-    z = torch.eye(x.shape[-1], device=x.device, dtype=y.dtype)
+    z = torch.eye(x.shape[-1], device=x.device)
     z = z.expand(x.shape[0], -1, -1)
 
-    for beta, alpha in _CANS_COEFFS:
-        p = z @ y
+    p = y
+    for beta, alpha in _CANS_COEFFS[:-1]:
         z = torch.baddbmm(z, p, z, beta=beta, alpha=alpha)
         y = torch.baddbmm(y, y, p, beta=beta, alpha=alpha)
+        p = z @ y
+
+    beta, alpha = _CANS_COEFFS[-1]
+    z = torch.baddbmm(z, p, z, beta=beta, alpha=alpha)
 
     z.mul_(torch.rsqrt(inf_norm))
     result = (z + z.mT) * 0.5

--- a/emerging_optimizers/soap/matrix_root_inverse_utils.py
+++ b/emerging_optimizers/soap/matrix_root_inverse_utils.py
@@ -44,11 +44,13 @@ def mat_root_inv_via_scaled_cans(
     Args:
         x: A 2D symmetric positive-definite FP32 matrix or 3D batch of matrices.
         eps: Lower bound used when normalizing the matrices.
-        fp32_matmul_prec: Precision used for FP32 matrix multiplications: ``"medium"`` for BF16,
-            ``"high"`` for TF32, or ``"highest"`` for FP32.
 
     Returns:
         The approximate inverse square root as an FP32 tensor with the same shape as ``x``.
+
+    Raises:
+        TypeError: If ``x`` is not a square FP32 matrix or batch of square FP32 matrices.
+        RuntimeError: If the active FP32 matmul precision is ``"medium"``.
     """
     # All constant arithmetic, including the 1.01 safety factor, is folded into these coefficients.
     _CANS_COEFFS = (
@@ -68,6 +70,8 @@ def mat_root_inv_via_scaled_cans(
         raise TypeError(f"x must be a square matrix or batch of square matrices, got shape {tuple(x.shape)}")
     if x.dtype != torch.float32:
         raise TypeError(f"x must be in float32, got {x.dtype}")
+    if torch.get_float32_matmul_precision() == "medium":
+        raise RuntimeError("`medium` (bf16 compute) is insufficient for CANS, use `high` or `highest`")
 
     is_batched = x.dim() == 3
     if not is_batched:
@@ -75,8 +79,6 @@ def mat_root_inv_via_scaled_cans(
 
     inf_norm = torch.linalg.matrix_norm(x, ord=float("inf"), dim=(-2, -1), keepdim=True).clamp_min_(eps)
     y = x / inf_norm
-    if torch.get_float32_matmul_precision() == "medium":
-        y = y.to(torch.bfloat16)
 
     z = torch.eye(x.shape[-1], device=x.device, dtype=y.dtype)
     z = z.expand(x.shape[0], -1, -1)
@@ -86,7 +88,6 @@ def mat_root_inv_via_scaled_cans(
         z = torch.baddbmm(z, p, z, beta=beta, alpha=alpha)
         y = torch.baddbmm(y, y, p, beta=beta, alpha=alpha)
 
-    z = z.to(torch.float32)
     z.mul_(torch.rsqrt(inf_norm))
     result = (z + z.mT) * 0.5
     return result if is_batched else result.squeeze(0)

--- a/tests/test_matrix_root_inverse_utils.py
+++ b/tests/test_matrix_root_inverse_utils.py
@@ -37,7 +37,7 @@ def setUpModule() -> None:
 class MatrixRootInverseUtilsTest(parameterized.TestCase):
     @parameterized.product(
         shape=[(4, 4), (2, 4, 4)],
-        fp32_matmul_prec=["medium", "high", "highest"],
+        fp32_matmul_prec=["high", "highest"],
     )
     def test_mat_root_inv_via_scaled_cans_smoke(
         self,
@@ -86,6 +86,13 @@ class MatrixRootInverseUtilsTest(parameterized.TestCase):
     def test_mat_root_inv_via_scaled_cans_rejects_non_fp32_tensor(self) -> None:
         with self.assertRaisesRegex(TypeError, "must be in float32"):
             mat_root_inv_via_scaled_cans(torch.eye(4, device=FLAGS.device, dtype=torch.bfloat16))
+
+    def test_mat_root_inv_via_scaled_cans_rejects_medium_fp32_matmul_precision(self) -> None:
+        with (
+            utils.fp32_matmul_precision("medium"),
+            self.assertRaisesRegex(RuntimeError, "`medium`.*insufficient for CANS"),
+        ):
+            mat_root_inv_via_scaled_cans(torch.eye(4, device=FLAGS.device))
 
     @parameterized.parameters(8, 16, 32)
     def test_inv_root_via_eigh_reconstruct_idendity(self, m) -> None:


### PR DESCRIPTION
Disallow bf16 compute for CANS

Saved couple of mm by moving things out of main loop. Slight readability loss.

@xsgxlz provided test case showing that bf16 compute is insufficient for CANS. Choices are to silently uses higher precision or raise error. decided to raise error.

```
import torch

from emerging_optimizers.soap.matrix_root_inverse_utils import (
    mat_root_inv_via_scaled_cans,
)

device = "cuda"
size = 1024

generator = torch.Generator(device=device).manual_seed(0)
x = torch.randn(size, size, generator=generator, device=device)

matrix = (x @ x.T) / size
matrix.diagonal().add_(1e-6)

with torch.no_grad():
    for precision in ("medium", "high"):
        inverse_root = mat_root_inv_via_scaled_cans(
            matrix,
            fp32_matmul_prec=precision,
        )

        print(f"{precision}:")
        print("  finite:", torch.isfinite(inverse_root).sum().item())
        print("  NaN:", torch.isnan(inverse_root).sum().item())
        print("  Inf:", torch.isinf(inverse_root).sum().item())
```