### PR TITLE
Improve typing

### DIFF
--- a/emerging_optimizers/registry.py
+++ b/emerging_optimizers/registry.py
@@ -24,10 +24,10 @@ from torch.optim.optimizer import ParamsT
 _OPTIMIZERS: dict[str, type[optim.Optimizer]] = {}
 
 
-def register_optimizer(name: str) -> Callable[[type[optim.Optimizer]], type[optim.Optimizer]]:
+def register_optimizer[Opt: optim.Optimizer](name: str) -> Callable[[type[Opt]], type[Opt]]:
     """Decorator to register an optimizer class in the registry."""
 
-    def decorator(cls: type[optim.Optimizer]) -> type[optim.Optimizer]:
+    def decorator(cls: type[Opt]) -> type[Opt]:
         if name.lower() in _OPTIMIZERS:
             raise ValueError(f"Optimizer {name} already registered.")
         _OPTIMIZERS[name.lower()] = cls
@@ -71,7 +71,7 @@ def get_optimizer_cls(name: str) -> type[optim.Optimizer]:
     return optimizer
 
 
-def validate_optimizer_args(opt_cls: type, kwargs: dict[str, Any]) -> None:
+def validate_optimizer_args(opt_cls: type[optim.Optimizer], kwargs: dict[str, Any]) -> None:
     """Checks if kwargs are valid for the optimizer class signature."""
     sig = signature(opt_cls)
 


### PR DESCRIPTION
Now optimizers actually retain their specific type (according to purely type-based information, at least) after being added to the registery.