### PR TITLE
Expose `Muon` parameters

### DIFF
--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -91,6 +91,9 @@ class Muon(OrthogonalizedOptimizer):
             raise ValueError(f"num_ns_steps must be at least 1, got {num_ns_steps}")
 
         self._num_ns_steps = num_ns_steps
+        self._coefficient_type = coefficient_type
+        self._scale_mode = scale_mode
+        self._extra_scale_factor = extra_scale_factor
 
         if use_syrk:
             if torch.cuda.is_available():
@@ -106,6 +109,7 @@ class Muon(OrthogonalizedOptimizer):
                     sm_version,
                 )
                 use_syrk = False
+        self._use_syrk = use_syrk
 
         def scaled_orthogonalize_fn(grad: torch.Tensor) -> torch.Tensor:
             logging.debug(
@@ -142,6 +146,38 @@ class Muon(OrthogonalizedOptimizer):
     @num_ns_steps.setter
     def num_ns_steps(self, _value: int) -> None:
         raise AttributeError("Cannot set `num_ns_steps` post-initialization.")
+
+    @property
+    def coefficient_type(self) -> NSCoeffT:
+        return self._coefficient_type
+
+    @coefficient_type.setter
+    def coefficient_type(self, _value: NSCoeffT) -> None:
+        raise AttributeError("Cannot set `coefficient_type` post-initialization.")
+
+    @property
+    def scale_mode(self) -> MuonScaleT:
+        return self._scale_mode
+
+    @scale_mode.setter
+    def scale_mode(self, _value: MuonScaleT) -> None:
+        raise AttributeError("Cannot set `scale_mode` post-initialization.")
+
+    @property
+    def extra_scale_factor(self) -> float:
+        return self._extra_scale_factor
+
+    @extra_scale_factor.setter
+    def extra_scale_factor(self, _value: float) -> None:
+        raise AttributeError("Cannot set `extra_scale_factor` post-initialization.")
+
+    @property
+    def use_syrk(self) -> bool:
+        return self._use_syrk
+
+    @use_syrk.setter
+    def use_syrk(self, _value: bool) -> None:
+        raise AttributeError("Cannot set `use_syrk` post-initialization.")
 
 
 Muon.__doc__ = Muon.__doc__.format(_args_doc=_args_doc)  # type: ignore[union-attr]

--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -140,7 +140,7 @@ class Muon(OrthogonalizedOptimizer):
         return self._num_ns_steps
 
     @num_ns_steps.setter
-    def num_ns_steps(self, value: int) -> None:
+    def num_ns_steps(self, _value: int) -> None:
         raise AttributeError("Cannot set `num_ns_steps` post-initialization.")
 
 

--- a/emerging_optimizers/orthogonalized_optimizers/muon.py
+++ b/emerging_optimizers/orthogonalized_optimizers/muon.py
@@ -90,6 +90,8 @@ class Muon(OrthogonalizedOptimizer):
         if num_ns_steps < 1:
             raise ValueError(f"num_ns_steps must be at least 1, got {num_ns_steps}")
 
+        self._num_ns_steps = num_ns_steps
+
         if use_syrk:
             if torch.cuda.is_available():
                 sm_version = torch.cuda.get_device_capability()
@@ -132,6 +134,14 @@ class Muon(OrthogonalizedOptimizer):
             fp32_matmul_prec=fp32_matmul_prec,
             scaled_orthogonalize_fn=scaled_orthogonalize_fn,
         )
+
+    @property
+    def num_ns_steps(self) -> int:
+        return self._num_ns_steps
+
+    @num_ns_steps.setter
+    def num_ns_steps(self, value: int) -> None:
+        raise AttributeError("Cannot set `num_ns_steps` post-initialization.")
 
 
 Muon.__doc__ = Muon.__doc__.format(_args_doc=_args_doc)  # type: ignore[union-attr]

--- a/tests/test_orthogonalized_optimizer.py
+++ b/tests/test_orthogonalized_optimizer.py
@@ -248,6 +248,38 @@ class MuonTest(parameterized.TestCase):
         muon_opt = muon.Muon([test_param], weight_decay_method=weight_decay_method, nesterov=nesterov)
         muon_opt.step()
 
+    def test_read_only_attributes(self) -> None:
+        """Smoke test Muon optimizer attribute access.
+        Most functionality of muon is tested in muon_utils. This test only entures everything run through
+        the optimizer class.
+        """
+        test_param = nn.Parameter(torch.randn(5, 7, dtype=torch.float32, device=self.device))
+
+        num_ns_steps = 5
+        coefficient_type = "quintic"
+        scale_mode = "spectral"
+        extra_scale_factor = 1.0
+        use_syrk = False
+
+        muon_opt = muon.Muon([test_param])
+
+        self.assertEqual(muon_opt.num_ns_steps, num_ns_steps)
+        self.assertEqual(muon_opt.coefficient_type, coefficient_type)
+        self.assertEqual(muon_opt.scale_mode, scale_mode)
+        self.assertEqual(muon_opt.extra_scale_factor, extra_scale_factor)
+        self.assertEqual(muon_opt.use_syrk, use_syrk)
+
+        with self.assertRaisesRegex(AttributeError, "Cannot set `num_ns_steps`"):
+            muon_opt.num_ns_steps = num_ns_steps
+        with self.assertRaisesRegex(AttributeError, "Cannot set `coefficient_type`"):
+            muon_opt.coefficient_type = coefficient_type
+        with self.assertRaisesRegex(AttributeError, "Cannot set `scale_mode`"):
+            muon_opt.scale_mode = scale_mode
+        with self.assertRaisesRegex(AttributeError, "Cannot set `extra_scale_factor`"):
+            muon_opt.extra_scale_factor = extra_scale_factor
+        with self.assertRaisesRegex(AttributeError, "Cannot set `use_syrk`"):
+            muon_opt.use_syrk = use_syrk
+
     def test_use_syrk_match_without_syrk(self) -> None:
         shape = (32, 32)
         test_param = nn.Parameter(torch.randint(-5, 5, shape, dtype=torch.float32, device=self.device))


### PR DESCRIPTION
It can be useful to obtain the `num_ns_steps` in certain cases, e.g., to balance compute around existing instances' `num_ns_steps`.

Could also refactor this to allow people to set `num_ns_steps` post-init by either (a) creating a new `scaled_orthogonalize_fn` when setting `num_ns_steps` or (b) simply passing `self` into the
`scaled_orthogonalize_fn` closure, so that the instance's current `num_ns_steps` are always accessed.